### PR TITLE
feat: allow for Firestore pagination of chat messages

### DIFF
--- a/lib/chat/chat_messenger.dart
+++ b/lib/chat/chat_messenger.dart
@@ -37,24 +37,87 @@ class ChatMessengerState extends State<ChatMessenger> {
 
   Store<AppState> store;
 
+  List<DocumentSnapshot> _messagesSnapshots;
+  bool _isLoading = false;
+  Message lastMessage;
   String recipient;
 
   File imageFile;
   String imageUrl;
 
   final TextEditingController textInputController = TextEditingController();
+  final ScrollController scrollController = ScrollController();
   final ImagePicker imagePicker = ImagePicker();
+
+  @override
+  void setState(fn) {
+    if (mounted) {
+      super.setState(fn);
+    }
+  }
 
   @override
   void initState() {
     super.initState();
     imageUrl = '';
+
+    scrollController.addListener(() {
+      if (scrollController.position.atEdge) {
+        if (scrollController.position.pixels != 0) {
+          var message = Message.fromJson(
+            _messagesSnapshots[_messagesSnapshots.length - 1]
+          );
+          Firestore.instance
+            .collection('messages')
+            .document(widget.groupChatId)
+            .collection(widget.groupChatId)
+            .where('timestamp', isLessThan: message.timestamp)
+            .orderBy('timestamp', descending: true)
+            .limit(20)
+            .getDocuments()
+            .then((snapshot) {
+              setState(() {
+                loadNewMessages();
+                _messagesSnapshots.addAll(snapshot.documents);
+              });
+            });
+        }
+      }
+    });
+  }
+
+  loadNewMessages() {
+    _isLoading = true;
+    Firestore.instance
+      .collection('messages')
+      .document(widget.groupChatId)
+      .collection(widget.groupChatId)
+      .orderBy('timestamp', descending: true)
+      .limit(1)
+      .snapshots()
+      .listen((onData) {
+        if (onData.documents[0] != null) {
+          var result = Message.fromJson(onData.documents[0]);
+          if (lastMessage.toString() != result.toString()) {
+            setState(() {
+              _isLoading = false;
+            });
+          }
+        }
+      });
   }
 
   void submitMessage (int type, String content) {
     if (content.trim() != '') {
       textInputController.clear();
-      addMessage(widget.id, widget.peerId, content, type, widget.groupChatId);
+      var message = Message(
+        idTo: widget.peerId,
+        idFrom: widget.id,
+        content: content,
+        type: type,
+        timestamp: DateTime.now().millisecondsSinceEpoch.toString()
+      );
+      addMessage(message, widget.groupChatId);
       SystemSound.play(SystemSoundType.click);
     }
   }
@@ -185,18 +248,25 @@ class ChatMessengerState extends State<ChatMessenger> {
           child: GestureDetector(
             onTap: () => FocusScope.of(context).unfocus(),
             child: StreamBuilder(
-              stream: Firestore.instance
-                .collection('messages')
-                .document(widget.groupChatId)
-                .collection(widget.groupChatId)
-                .orderBy('timestamp', descending: true)
-                .limit(20)
-                .snapshots(),
+              stream: _isLoading ?
+                null : 
+                Firestore.instance
+                  .collection('messages')
+                  .document(widget.groupChatId)
+                  .collection(widget.groupChatId)
+                  .orderBy('timestamp', descending: true)
+                  .limit(20)
+                  .snapshots(),
               builder: (context, snapshot) {
                 if (!snapshot.hasData) {
                   return Text("wait");
                 } else {
+                  _messagesSnapshots = snapshot
+                    .data
+                    .documents as List<DocumentSnapshot>;
+                  lastMessage = Message.fromJson(_messagesSnapshots[0]);
                   return ListView.builder(
+                    controller: scrollController,
                     itemBuilder: (context, index) => Column(
                       children: buildMessage(
                         index,

--- a/lib/services/message_service.dart
+++ b/lib/services/message_service.dart
@@ -3,27 +3,15 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import '../models/models.dart';
 import 'services.dart';
 
-Future<void> addMessage(
-  String idFrom, 
-  String idTo, 
-  String content, 
-  int type,
-  String groupChatId
-) async {
-  var message = Message(
-    idTo: idTo,
-    idFrom: idFrom,
-    content: content,
-    type: type,
-    timestamp: DateTime.now().millisecondsSinceEpoch.toString()
-  ).toJson();
+Future<void> addMessage(Message message, String groupChatId) async {
+  var messageJson = message.toJson();
 
   Firestore
     .instance
     .collection('messages')
     .document(groupChatId)
     .collection(groupChatId)
-    .add(message);
+    .add(messageJson);
 
-  updateMatchesLastMessage(message, groupChatId);
+  updateMatchesLastMessage(messageJson, groupChatId);
 }

--- a/lib/services/message_service.dart
+++ b/lib/services/message_service.dart
@@ -15,3 +15,30 @@ Future<void> addMessage(Message message, String groupChatId) async {
 
   updateMatchesLastMessage(messageJson, groupChatId);
 }
+
+Stream<QuerySnapshot> getMessageSnapshots(
+  String groupChatId, 
+  int messageLimit
+) {
+  return Firestore.instance
+    .collection('messages')
+    .document(groupChatId)
+    .collection(groupChatId)
+    .orderBy('timestamp', descending: true)
+    .limit(messageLimit)
+    .snapshots();
+}
+
+Future<QuerySnapshot> getMessagesOlderThanTimestamp(
+  String groupChatId,
+  String timestamp,
+) async {
+  return Firestore.instance
+    .collection('messages')
+    .document(groupChatId)
+    .collection(groupChatId)
+    .where('timestamp', isLessThan: timestamp)
+    .orderBy('timestamp', descending: true)
+    .limit(20)
+    .getDocuments();
+}


### PR DESCRIPTION
**Changes**
- streams firestore chat messages in chunks to allow the user to scroll up and load more messages
- add a scrollListener to only load more messages when the user is at the top of the chat messenger
