### PR TITLE
feat: add user type in user state and entity

### DIFF
--- a/lib/constants/common_constants.dart
+++ b/lib/constants/common_constants.dart
@@ -14,6 +14,12 @@ const loginAction = 'Login';
 const globalHeaderFontSize = 22.0;
 const globalHeaderActionsFontSize = 16.0; 
 
+ // User types
+enum UserType {
+  mentor,
+  mentee
+}
+
  // Authentication
 enum AuthStatus {
   notDetermined,

--- a/lib/ftu/login_create_account/login.dart
+++ b/lib/ftu/login_create_account/login.dart
@@ -128,7 +128,9 @@ class _Login extends State<Login> {
     var userId = await Auth().signIn(emailAddress, password);
     var userData = await getUser(userId);
     if (userData == null) {
-      await addUser(userId, emailAddress);
+      // Adding mentee users for now
+      // TODO: Fix when refactoring signup
+      await addUser(userId, emailAddress, UserType.mentee);
       userData = await getUser(userId);
     }
     store.dispatch(ConvertToUserState(userData));

--- a/lib/helpers/enum_parser.dart
+++ b/lib/helpers/enum_parser.dart
@@ -1,0 +1,50 @@
+import '../constants/common_constants.dart';
+
+
+String parseUserTypeToString(UserType type) {
+  switch (type) {
+    case UserType.mentor:
+      return "mentor";
+    case UserType.mentee:
+      return "mentee";
+    default:
+      return '';
+  }
+}
+
+UserType parseUserTypeToValue(String type) {
+  switch (type) {
+    case "mentor":
+      return UserType.mentor;
+    case "mentee":
+      return UserType.mentee;
+    default:
+      return null;
+  }
+}
+
+String parseAuthStatusToString(AuthStatus authStatus) {
+  switch (authStatus) {
+    case AuthStatus.notDetermined:
+      return "notDetermined";
+    case AuthStatus.notLoggedIn:
+      return "notLoggedIn";
+    case AuthStatus.loggedIn:
+      return "loggedIn";
+    default:
+      return "notDetermined";
+  }
+}
+
+AuthStatus parseAuthStatusToValue(String authStatus) {
+  switch (authStatus) {
+    case "notDetermined":
+      return AuthStatus.notDetermined;
+    case "notLoggedIn":
+      return AuthStatus.notLoggedIn;
+    case "loggedIn":
+      return AuthStatus.loggedIn;
+    default:
+      return AuthStatus.notDetermined;
+  }
+}

--- a/lib/helpers/helpers.dart
+++ b/lib/helpers/helpers.dart
@@ -1,0 +1,2 @@
+export 'enum_parser.dart';
+export 'user_entity_helper.dart';

--- a/lib/models/entities/user.dart
+++ b/lib/models/entities/user.dart
@@ -1,12 +1,15 @@
 import 'dart:convert';
 import 'package:meta/meta.dart';
 
+import '../../constants/common_constants.dart';
+import '../../helpers/helpers.dart';
 import '../models.dart';
 
 
 @immutable
 class User {
   final String id;
+  final UserType type;
   final bool isFtu;
   final String fullName;
   final String summary;
@@ -17,6 +20,7 @@ class User {
 
   const User({
     @required this.id,
+    @required this.type,
     @required this.isFtu,
     @required this.contact,
     this.fullName,
@@ -29,6 +33,7 @@ class User {
   factory User.initial() {
     return User(
       id: '',
+      type: null,
       isFtu: true,
       fullName: '',
       summary: '',
@@ -41,6 +46,7 @@ class User {
 
   User copyWith({
     String id,
+    UserType type,
     bool isFtu,
     String fullName,
     String summary,
@@ -51,6 +57,7 @@ class User {
   }) {
     return User(
       id: id ?? this.id,
+      type: type ?? this.type,
       isFtu: isFtu ?? this.isFtu,
       fullName: fullName ?? this.fullName,
       summary: summary ?? this.summary,
@@ -67,6 +74,7 @@ class User {
     var skillsJson = json['skills'] as List;
     return User(
       id: json["id"] as String,
+      type: parseUserTypeToValue(json["type"]),
       isFtu: json["isFtu"] as bool,
       fullName: json["fullName"] as String,
       summary: json["summary"] as String,
@@ -79,6 +87,7 @@ class User {
 
   dynamic toJson() => {
     'id': id,
+    'type': parseUserTypeToString(type),
     'isFtu': isFtu,
     'fullName': fullName,
     'summary': summary,

--- a/lib/models/states/user_state.dart
+++ b/lib/models/states/user_state.dart
@@ -2,18 +2,21 @@ import 'dart:convert';
 import 'package:meta/meta.dart';
 
 import '../../constants/common_constants.dart';
+import '../../helpers/helpers.dart';
 import '../models.dart';
 
 
 @immutable
 class UserState {
   final String id;
+  final UserType type;
   final bool isFtu;
   final AuthStatus authStatus;
   final SaveProfileState saveProfileState;
 
   const UserState({
     @required this.id,
+    @required this.type,
     @required this.isFtu,
     this.authStatus,
     this.saveProfileState
@@ -22,6 +25,7 @@ class UserState {
   factory UserState.initial() {
     return UserState(
       id: '',
+      type: null,
       isFtu: true,
       authStatus: AuthStatus.notDetermined,
       saveProfileState: SaveProfileState.initial()
@@ -30,12 +34,14 @@ class UserState {
 
   UserState copyWith({
     String id,
+    UserType type,
     bool isFtu,
     AuthStatus authStatus,
     SaveProfileState saveProfileState
   }) {
     return UserState(
       id: id ?? this.id,
+      type: type ?? this.type,
       isFtu: isFtu ?? this.isFtu,
       authStatus: authStatus ?? this.authStatus,
       saveProfileState: saveProfileState ?? this.saveProfileState
@@ -45,6 +51,7 @@ class UserState {
   static UserState fromJson(dynamic json) {
     return UserState(
       id: json["id"] as String,
+      type: parseUserTypeToValue(json["type"]),
       isFtu: json["isFtu"] as bool,
       authStatus: parseAuthStatusToValue(json["authStatus"]),
       saveProfileState: SaveProfileState.fromJson(json["saveProfileState"])
@@ -53,36 +60,11 @@ class UserState {
 
   dynamic toJson() => {
     'id': id,
+    'type': parseUserTypeToString(type),
     'isFtu': isFtu,
     'authStatus': parseAuthStatusToString(authStatus),
     'saveProfileState': saveProfileState.toJson()
   };
-
-  static String parseAuthStatusToString(AuthStatus authStatus) {
-    switch (authStatus) {
-      case AuthStatus.notDetermined:
-        return "notDetermined";
-      case AuthStatus.notLoggedIn:
-        return "notLoggedIn";
-      case AuthStatus.loggedIn:
-        return "loggedIn";
-      default:
-        return "notDetermined";
-    }
-  }
-
-  static AuthStatus parseAuthStatusToValue(String authStatus) {
-    switch (authStatus) {
-      case "notDetermined":
-        return AuthStatus.notDetermined;
-      case "notLoggedIn":
-        return AuthStatus.notLoggedIn;
-      case "loggedIn":
-        return AuthStatus.loggedIn;
-      default:
-        return AuthStatus.notDetermined;
-    }
-  }
 
   @override
   String toString() {

--- a/lib/reducers/user_reducer.dart
+++ b/lib/reducers/user_reducer.dart
@@ -16,6 +16,7 @@ UserState _userReducer(UserState userState, dynamic action) {
       var user = User.fromJson(action.payload);
       return UserState.initial().copyWith(
         id: user.id,
+        type: user.type,
         isFtu: user.isFtu,
         authStatus: AuthStatus.loggedIn,
         saveProfileState: SaveProfileState.initial().copyWith(

--- a/lib/selectors/user_selector.dart
+++ b/lib/selectors/user_selector.dart
@@ -7,6 +7,10 @@ UserState userStateSelector(Store<AppState> store) {
   return store.state.userState;
 }
 
+UserType userTypeSelector(Store<AppState> store) {
+  return store.state.userState.type;
+}
+
 AuthStatus authStatusSelector(Store<AppState> store) {
   return store.state.userState.authStatus;
 }

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+import '../constants/common_constants.dart';
 import '../models/models.dart';
 
 Future<Map<String, dynamic>> getUser(String id) async {
@@ -17,9 +18,10 @@ Future<QuerySnapshot> getUsers() async {
     .getDocuments();
 }
 
-Future<void> addUser(String id, String email) async {
+Future<void> addUser(String id, String email, UserType type) async {
   var user = User.initial().copyWith(
     id: id,
+    type: type,
     contact: Contact.initial().copyWith(
       emailAddress: email
     )


### PR DESCRIPTION
**Changes**
- Added attribute `type` in both user entity and state.
- For now, we're only adding `mentee` type users but I will fix that in my next PR where I refactor the signup page.
- Manually added the `type="mentee"` field on Firebase for the valid users that we currently have (mine, helen's and rex's), so we don't have to nuke it again just for this change;

**UI**
> N/A
