### PR TITLE
feat: update chat ui to match mockup

### DIFF
--- a/lib/chat/chat.dart
+++ b/lib/chat/chat.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:redux/redux.dart';
 
+import '../common/global_header.dart';
 import '../constants/constants.dart';
 import '../models/models.dart';
 import '../selectors/selectors.dart';
@@ -70,44 +71,15 @@ class _ChatState extends State<Chat> {
   }
 }
 
-buildHeader() {
-  return Container (
-    margin: EdgeInsets.all(30.0),
-    child: Column(
-      children: <Text>[
-        Text(
-          chatHeaderTitle, 
-          style: GoogleFonts.muli(
-            textStyle: TextStyle(
-              color: Colors.black, 
-              letterSpacing: .5, 
-              fontSize: 30.0, 
-              fontWeight: FontWeight.bold
-            )
-          )
-        ), 
-        Text(
-          chatHeaderSubtitle, 
-          style: GoogleFonts.muli(
-            textStyle: TextStyle(
-              color: Colors.grey, 
-              letterSpacing: .5, 
-              fontSize: 18, 
-              fontWeight: FontWeight.w600
-            )
-          )
-        ), 
-      ]
-    )
-  );
-}
-
 buildChatView(var newMatchesList, var matchesList) {
   return (
     <Widget>[
-      buildHeader(),
-      if (newMatchesList.length != 0)
-        NewMatches(newMatchesList: newMatchesList),
+      GlobalHeader(
+        actionText: "New Message",
+        onActionTap: () => {},
+      ),
+      // if (newMatchesList.length != 0)
+        NewMatches(newMatchesList: matchesList),
       if (matchesList.length != 0)
         Flexible(
           child: UserMessageRows(matchesList: matchesList)

--- a/lib/chat/chat.dart
+++ b/lib/chat/chat.dart
@@ -1,5 +1,4 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:redux/redux.dart';

--- a/lib/chat/chat.dart
+++ b/lib/chat/chat.dart
@@ -78,8 +78,8 @@ buildChatView(var newMatchesList, var matchesList) {
         actionText: "New Message",
         onActionTap: () => {},
       ),
-      // if (newMatchesList.length != 0)
-        NewMatches(newMatchesList: matchesList),
+      if (newMatchesList.length != 0)
+        NewMatches(newMatchesList: newMatchesList),
       if (matchesList.length != 0)
         Flexible(
           child: UserMessageRows(matchesList: matchesList)

--- a/lib/chat/chat_messenger.dart
+++ b/lib/chat/chat_messenger.dart
@@ -158,7 +158,6 @@ class ChatMessengerState extends State<ChatMessenger> {
     return Container(
       decoration: BoxDecoration(
         color: Colors.white,
-        // border: Border(top: BorderSide(width: 1.0, color: Colors.grey[100]))
       ),
       constraints: BoxConstraints(minHeight: 50.0, maxHeight: 200.0),
       padding: EdgeInsets.all(15.0),

--- a/lib/chat/chat_messenger.dart
+++ b/lib/chat/chat_messenger.dart
@@ -101,7 +101,8 @@ class ChatMessengerState extends State<ChatMessenger> {
         idFrom: widget.id,
         content: content,
         type: type,
-        timestamp: DateTime.now().millisecondsSinceEpoch.toString()
+        timestamp: DateTime.now().millisecondsSinceEpoch.toString(),
+        isRead: false,
       );
       addMessage(message, widget.groupChatId);
       SystemSound.play(SystemSoundType.click);
@@ -157,49 +158,64 @@ class ChatMessengerState extends State<ChatMessenger> {
     return Container(
       decoration: BoxDecoration(
         color: Colors.white,
-        border: Border(top: BorderSide(width: 1.0, color: Colors.grey[100]))
+        // border: Border(top: BorderSide(width: 1.0, color: Colors.grey[100]))
       ),
-      constraints: BoxConstraints(minHeight: 70.0, maxHeight: 200.0),
-      padding: EdgeInsets.only(bottom: 15.0),
+      constraints: BoxConstraints(minHeight: 50.0, maxHeight: 200.0),
+      padding: EdgeInsets.all(15.0),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         crossAxisAlignment: CrossAxisAlignment.end,
         children: <Widget>[
-          IconButton(
-            icon: Icon(Icons.photo),
-            iconSize: 25.0,
-            color: Theme.of(context).primaryColor,
-            onPressed: () => pickImage(ImageSource.gallery),
-          ),
-          IconButton(
-            icon: Icon(Icons.camera),
-            iconSize: 25.0,
-            color: Theme.of(context).primaryColor,
-            onPressed: () => pickImage(ImageSource.camera),
-          ),
           Expanded(
-            child: TextField(
-              textCapitalization: TextCapitalization.sentences,
-              decoration: InputDecoration.collapsed(
-                hintText: 'Send a message...'
+            child: Container(
+              decoration: BoxDecoration(
+                border: Border.all(width: 1.0, color: Colors.grey[300]),
               ),
-              style: GoogleFonts.muli(
-                textStyle: TextStyle(
-                  color: Colors.black, 
-                  letterSpacing: .5, 
-                  fontSize: 14.0, 
-                )
-              ),
-              maxLines: null, // this allows for multi-line input
-              textInputAction: TextInputAction.send,
-              controller: textInputController,
-              onSubmitted: (value) => submitMessage(textMessage, value),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: <Widget>[
+                  IconButton(
+                    icon: Icon(Icons.photo),
+                    iconSize: 24.0,
+                    padding: EdgeInsets.all(0.0),
+                    color: Theme.of(context).accentColor,
+                    onPressed: () => pickImage(ImageSource.gallery),
+                  ),
+                  IconButton(
+                    icon: Icon(Icons.camera_alt),
+                    iconSize: 24.0,
+                    padding: EdgeInsets.all(0.0),
+                    color: Theme.of(context).accentColor,
+                    onPressed: () => pickImage(ImageSource.camera),
+                  ),
+                  Expanded(
+                    child: TextField(
+                      textCapitalization: TextCapitalization.sentences,
+                      decoration: InputDecoration.collapsed(
+                        hintText: 'Send a message...',
+                      ),
+                      style: GoogleFonts.muli(
+                        textStyle: TextStyle(
+                          color: Colors.black, 
+                          letterSpacing: .5, 
+                          fontSize: 14.0, 
+                        )
+                      ),
+                      maxLines: null, // this allows for multi-line input
+                      textInputAction: TextInputAction.send,
+                      controller: textInputController,
+                      onSubmitted: (value) => submitMessage(textMessage, value),
+                    )
+                  ),
+                ]
+              )
             )
           ),
           IconButton(
             icon: Icon(Icons.send),
-            iconSize: 25.0,
-            color: Theme.of(context).primaryColor,
+            iconSize: 24.0,
+            padding: EdgeInsets.all(0.0),
+            color: Theme.of(context).accentColor,
             onPressed: () => submitMessage(
               textMessage, textInputController.value.text
             ),
@@ -274,25 +290,48 @@ class ChatMessengerState extends State<ChatMessenger> {
       children: <Widget>[
         Scaffold(
           appBar: AppBar(
+            // remove bottom shadow
+            elevation: 0.0,
             leading: IconButton(
               onPressed: () {
                 Navigator.pop(context);
               },
-              icon: Icon(Icons.arrow_back, color: Colors.white)
-            ),
-            backgroundColor: Theme.of(context).primaryColor,
-            centerTitle: true,
-            title: Text(
-              widget.recipient,
-              style: GoogleFonts.muli(
-                textStyle: TextStyle(
-                  color: Colors.white, 
-                  letterSpacing: .5, 
-                  fontSize: 30.0, 
-                  fontWeight: FontWeight.bold
-                )
+              icon: Icon(
+                Icons.arrow_back_ios,
+                color: Theme.of(context).accentColor
               )
             ),
+            backgroundColor: Colors.white,
+            centerTitle: true,
+            title: Column (
+              children: <Widget>[
+                Container(
+                  width: 35.0,
+                  height: 35.0,
+                  child: Center(
+                    child: Container(
+                      width: 35.0, 
+                      height: 35.0, 
+                      decoration: BoxDecoration(
+                        color: Colors.black, 
+                        shape: BoxShape.circle
+                      )
+                    )
+                  )
+                ),
+                Text(
+                  widget.recipient,
+                  style: GoogleFonts.muli(
+                    textStyle: TextStyle(
+                      color: Colors.black, 
+                      letterSpacing: .5, 
+                      fontSize: 14.0, 
+                      fontWeight: FontWeight.bold
+                    )
+                  )
+                ),
+              ],
+            )
           ),
           backgroundColor: Colors.white,
           body: Container(

--- a/lib/chat/chat_messenger.dart
+++ b/lib/chat/chat_messenger.dart
@@ -10,9 +10,11 @@ import 'package:image_picker/image_picker.dart';
 import 'package:intl/intl.dart';
 import 'package:redux/redux.dart';
 
+import '../common/common.dart';
 import '../constants/chat_constants.dart';
 import '../models/models.dart';
 import '../services/services.dart';
+import './common/profile_picture.dart';
 import './message.dart';
 
 class ChatMessenger extends StatefulWidget {
@@ -154,6 +156,38 @@ class ChatMessengerState extends State<ChatMessenger> {
     }
   }
 
+  IconButton buildKeyboardIconButton(Icon icon, Function onPressed) {
+    return IconButton(
+      icon: icon,
+      iconSize: 24.0,
+      padding: EdgeInsets.all(0.0),
+      color: Theme.of(context).accentColor,
+      onPressed: onPressed,
+    );
+  }
+
+  Widget buildKeyboardTextInput() {
+    return Expanded(
+      child: TextField(
+        textCapitalization: TextCapitalization.sentences,
+        decoration: InputDecoration.collapsed(
+          hintText: keyboardInputHintText,
+        ),
+        style: GoogleFonts.muli(
+          textStyle: TextStyle(
+            color: Colors.black, 
+            letterSpacing: .5, 
+            fontSize: 14.0, 
+          )
+        ),
+        maxLines: null, // this allows for multi-line input
+        textInputAction: TextInputAction.send,
+        controller: textInputController,
+        onSubmitted: (value) => submitMessage(textMessage, value),
+      )
+    );
+  }
+
   Widget buildMessengerKeyboard() {
     return Container(
       decoration: BoxDecoration(
@@ -173,51 +207,24 @@ class ChatMessengerState extends State<ChatMessenger> {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: <Widget>[
-                  IconButton(
-                    icon: Icon(Icons.photo),
-                    iconSize: 24.0,
-                    padding: EdgeInsets.all(0.0),
-                    color: Theme.of(context).accentColor,
-                    onPressed: () => pickImage(ImageSource.gallery),
+                  buildKeyboardIconButton(
+                    Icon(Icons.photo), 
+                    () => pickImage(ImageSource.gallery)
                   ),
-                  IconButton(
-                    icon: Icon(Icons.camera_alt),
-                    iconSize: 24.0,
-                    padding: EdgeInsets.all(0.0),
-                    color: Theme.of(context).accentColor,
-                    onPressed: () => pickImage(ImageSource.camera),
+                  buildKeyboardIconButton(
+                    Icon(Icons.camera_alt), 
+                    () => pickImage(ImageSource.camera)
                   ),
-                  Expanded(
-                    child: TextField(
-                      textCapitalization: TextCapitalization.sentences,
-                      decoration: InputDecoration.collapsed(
-                        hintText: 'Send a message...',
-                      ),
-                      style: GoogleFonts.muli(
-                        textStyle: TextStyle(
-                          color: Colors.black, 
-                          letterSpacing: .5, 
-                          fontSize: 14.0, 
-                        )
-                      ),
-                      maxLines: null, // this allows for multi-line input
-                      textInputAction: TextInputAction.send,
-                      controller: textInputController,
-                      onSubmitted: (value) => submitMessage(textMessage, value),
-                    )
-                  ),
+                  buildKeyboardTextInput(),
                 ]
               )
             )
           ),
-          IconButton(
-            icon: Icon(Icons.send),
-            iconSize: 24.0,
-            padding: EdgeInsets.all(0.0),
-            color: Theme.of(context).accentColor,
-            onPressed: () => submitMessage(
+          buildKeyboardIconButton(
+            Icon(Icons.send), 
+            () => submitMessage(
               textMessage, textInputController.value.text
-            ),
+            )
           ),
         ]
       )
@@ -283,6 +290,21 @@ class ChatMessengerState extends State<ChatMessenger> {
     );
   }
 
+  Widget buildAppBarTitle() {
+    return Column (
+      children: <Widget>[
+        ProfilePicture(
+          containerSideLength: 35.0, profilePictureRadius: 35.0
+        ),
+        FormatText(
+          text: widget.recipient,
+          fontSize: 14.0,
+          fontWeight: FontWeight.bold,
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Stack(
@@ -302,35 +324,7 @@ class ChatMessengerState extends State<ChatMessenger> {
             ),
             backgroundColor: Colors.white,
             centerTitle: true,
-            title: Column (
-              children: <Widget>[
-                Container(
-                  width: 35.0,
-                  height: 35.0,
-                  child: Center(
-                    child: Container(
-                      width: 35.0, 
-                      height: 35.0, 
-                      decoration: BoxDecoration(
-                        color: Colors.black, 
-                        shape: BoxShape.circle
-                      )
-                    )
-                  )
-                ),
-                Text(
-                  widget.recipient,
-                  style: GoogleFonts.muli(
-                    textStyle: TextStyle(
-                      color: Colors.black, 
-                      letterSpacing: .5, 
-                      fontSize: 14.0, 
-                      fontWeight: FontWeight.bold
-                    )
-                  )
-                ),
-              ],
-            )
+            title: buildAppBarTitle()
           ),
           backgroundColor: Colors.white,
           body: Container(

--- a/lib/chat/common/message_row.dart
+++ b/lib/chat/common/message_row.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:intl/intl.dart';
+
+import '../../common/common.dart';
+import '../../constants/constants.dart';
+import '../../models/models.dart';
+import '../chat_messenger.dart';
+import './profile_picture.dart';
+
+class MessageRow extends StatelessWidget {
+  final User recipient;
+  final String id;
+  final Match match;
+  MessageRow(
+    {
+      Key key, 
+      @required this.recipient,
+      @required this.id,
+      @required this.match,
+    }
+  ) : super(key: key);
+
+  Widget buildLastMessage(
+    context,
+    isSent,
+    isRead,
+    lastMessage,
+    lastMessageType
+  ) {
+    return RichText(
+      overflow: TextOverflow.ellipsis,
+      text: TextSpan(
+        style: GoogleFonts.muli(
+          textStyle: TextStyle(
+            color: Colors.grey,
+            letterSpacing: .5, 
+            fontSize: 12.0, 
+          )
+        ),
+        children: [
+          if(isSent != false)
+            WidgetSpan(
+              child: Container(
+                margin: EdgeInsets.only(right: 6.0),
+                child: Icon(
+                  Icons.send, 
+                  size: 12, 
+                  color: Colors.grey
+                )
+              ),
+            ),
+          TextSpan(
+            style: TextStyle(
+              color: isRead == true || isSent == true ? 
+                Colors.grey : 
+                Theme.of(context).accentColor,
+            ),
+            text: lastMessageType == 0 ? 
+              lastMessage.content : 
+              imageMessageDesciption
+          )
+        ]
+      ),
+    );
+  }
+
+  Widget buildNameAndTimestamp(lastMessage) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: <Widget>[
+        FormatText(
+          text: recipient.fullName,
+          fontSize: 14.0,
+        ),
+        Container(
+          padding: EdgeInsets.only(right: 10.0),
+          child: FormatText(
+            text: DateFormat('jm').format(
+              DateTime.fromMillisecondsSinceEpoch(
+                int.parse(lastMessage.timestamp)
+              )
+            ),
+            fontSize: 14.0,
+            fontWeight: FontWeight.w400,
+            textColor: Colors.grey,
+          )
+        )
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var lastMessage = match.lastMessage;
+    var lastMessageType = lastMessage.type;
+    var isSent = lastMessage.idFrom == id;
+    var isRead = !isSent && lastMessage.isRead;
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onTap: () {
+        Navigator.push(
+          context, 
+          MaterialPageRoute(builder: (context) => 
+            ChatMessenger(
+            recipient: recipient.fullName, 
+              peerId: recipient.id, 
+              id: id,
+              groupChatId: match.matchId,
+            )
+          )
+        );
+      },
+      child: Container(
+        margin: EdgeInsets.fromLTRB(30.0, 15.0, 30.0, 15.0),
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: isRead || isSent ? 
+              Colors.grey : 
+              Theme.of(context).accentColor, 
+            width: 1.0
+          ),
+          borderRadius: BorderRadius.all(Radius.circular(15.0)),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisSize: MainAxisSize.max, 
+          children: <Widget>[
+            ProfilePicture(
+              containerSideLength: 80.0,
+              profilePictureRadius: 60.0,
+            ),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  buildNameAndTimestamp(lastMessage),
+                  buildLastMessage(
+                    context,
+                    isSent,
+                    isRead,
+                    lastMessage,
+                    lastMessageType
+                  )
+                ]
+              )
+            )
+          ]
+        )
+      )
+    );
+  }
+}

--- a/lib/chat/common/profile_picture.dart
+++ b/lib/chat/common/profile_picture.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class ProfilePicture extends StatelessWidget {
+  final double containerSideLength;
+  final double profilePictureRadius;
+  ProfilePicture(
+    {Key key, this.containerSideLength = 80.0, this.profilePictureRadius = 60.0}
+  ) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: containerSideLength,
+      height: containerSideLength,
+      child: Center(
+        child: Container(
+          width: profilePictureRadius, 
+          height: profilePictureRadius, 
+          decoration: BoxDecoration(
+            color: Colors.black, 
+            shape: BoxShape.circle
+          )
+        )
+      )
+    );
+  }
+}

--- a/lib/chat/message.dart
+++ b/lib/chat/message.dart
@@ -1,8 +1,8 @@
 import 'package:bubble/bubble.dart';
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter/material.dart';
 
+import '../common/common.dart';
 import '../constants/chat_constants.dart';
 
 class MessageView extends StatelessWidget {
@@ -13,58 +13,69 @@ class MessageView extends StatelessWidget {
     {Key key, @required this.message, @required this.isSent, this.type}
   ) : super(key: key);
 
+  Widget buildTextMessageBubble(BuildContext context) {
+    var nip = isSent ? BubbleNip.rightTop : BubbleNip.leftTop;
+    var margin = isSent ? 
+      BubbleEdges.fromLTRB(50.0, 10.0, 10.0, 10.0) :
+      BubbleEdges.fromLTRB(10.0, 10.0, 50.0, 10.0);
+    var color = isSent ? Theme.of(context).accentColor : Colors.grey;
+    return Bubble(
+      nip: nip,
+      nipOffset: 0.0,
+      style: BubbleStyle(
+        margin: margin,
+        padding: BubbleEdges.all(10.0),
+        color: color,
+      ),
+      child: FormatText(
+        text: message,
+        fontSize: 14.0,
+        fontWeight: FontWeight.w400,
+      )
+    );
+  }
+
+  Widget buildImageMessageBubble(BuildContext context) {
+    var nip = isSent ? BubbleNip.rightTop : BubbleNip.leftTop;
+    var margin = isSent ? 
+      BubbleEdges.fromLTRB(50.0, 10.0, 10.0, 10.0) :
+      BubbleEdges.fromLTRB(10.0, 10.0, 50.0, 10.0);
+    var color = isSent ? Theme.of(context).accentColor : Colors.grey;
+    return Bubble(
+      nip: nip,
+      nipOffset: 0.0,
+      style: BubbleStyle(
+        margin: margin,
+        padding: BubbleEdges.all(10.0),
+        color: color,
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.all(Radius.circular(8.0)),
+        child: CachedNetworkImage(
+          imageUrl: message,
+          fit: BoxFit.fill,
+          placeholder: (context, url) => Container(
+            width: 200.0,
+            height: 200.0,
+            padding: EdgeInsets.all(70.0),
+            child: CircularProgressIndicator(
+              valueColor: AlwaysStoppedAnimation<Color>(Colors.white)
+            )
+          ),
+          errorWidget: (context, url, error) => Text("error"),
+        )
+      )
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    var alignment = isSent ? Alignment.centerRight : Alignment.centerLeft;
     return Align(
-      alignment: isSent ? Alignment.centerRight : Alignment.centerLeft,
+      alignment: alignment,
       child: type == textMessage ? 
-        Bubble(
-          nip: isSent ? BubbleNip.rightTop : BubbleNip.leftTop,
-          nipOffset: 0.0,
-          style: BubbleStyle(
-            margin: isSent ? 
-              BubbleEdges.fromLTRB(50.0, 10.0, 10.0, 10.0) :
-              BubbleEdges.fromLTRB(10.0, 10.0, 50.0, 10.0),
-            padding: BubbleEdges.all(10.0),
-            color: isSent ? Theme.of(context).accentColor : Colors.grey,
-          ),
-          child: Text(
-            message,
-            style: GoogleFonts.muli(
-              textStyle: TextStyle(
-                color: Colors.black, 
-                letterSpacing: .5, 
-                fontSize: 14.0, 
-              )
-            )
-          )
-        ) : Bubble(
-          nip: isSent ? BubbleNip.rightTop : BubbleNip.leftTop,
-          nipOffset: 0.0,
-          style: BubbleStyle(
-            margin: isSent ? 
-              BubbleEdges.fromLTRB(50.0, 10.0, 10.0, 10.0) :
-              BubbleEdges.fromLTRB(10.0, 10.0, 50.0, 10.0),
-            padding: BubbleEdges.all(10.0),
-            color: isSent ? Theme.of(context).accentColor : Colors.grey,
-          ),
-          child: ClipRRect(
-            borderRadius: BorderRadius.all(Radius.circular(8.0)),
-            child: CachedNetworkImage(
-              imageUrl: message,
-              fit: BoxFit.fill,
-              placeholder: (context, url) => Container(
-                width: 200.0,
-                height: 200.0,
-                padding: EdgeInsets.all(70.0),
-                child: CircularProgressIndicator(
-                  valueColor: AlwaysStoppedAnimation<Color>(Colors.white)
-                )
-              ),
-              errorWidget: (context, url, error) => Text("error"),
-            )
-          )
-        )
+        buildTextMessageBubble(context) : 
+        buildImageMessageBubble(context)
     );
   }
 }

--- a/lib/chat/message.dart
+++ b/lib/chat/message.dart
@@ -1,3 +1,4 @@
+import 'package:bubble/bubble.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter/material.dart';
@@ -16,50 +17,54 @@ class MessageView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Align(
       alignment: isSent ? Alignment.centerRight : Alignment.centerLeft,
-      child: type == textMessage ? Container(
-        decoration: BoxDecoration(
-          color: isSent ? Theme.of(context).accentColor : Colors.grey,
-          borderRadius: BorderRadius.all(Radius.circular(8.0)),
-        ),
-        margin: isSent 
-          ? EdgeInsets.fromLTRB(50.0, 10.0, 10.0, 10.0) 
-          : EdgeInsets.fromLTRB(10.0, 10.0, 50.0, 10.0),
-        padding: EdgeInsets.all(10.0),
-        child: Text(
-          message,
-          style: GoogleFonts.muli(
-            textStyle: TextStyle(
-              color: Colors.white, 
-              letterSpacing: .5, 
-              fontSize: 14.0, 
+      child: type == textMessage ? 
+        Bubble(
+          nip: isSent ? BubbleNip.rightTop : BubbleNip.leftTop,
+          nipOffset: 0.0,
+          style: BubbleStyle(
+            margin: isSent ? 
+              BubbleEdges.fromLTRB(50.0, 10.0, 10.0, 10.0) :
+              BubbleEdges.fromLTRB(10.0, 10.0, 50.0, 10.0),
+            padding: BubbleEdges.all(10.0),
+            color: isSent ? Theme.of(context).accentColor : Colors.grey,
+          ),
+          child: Text(
+            message,
+            style: GoogleFonts.muli(
+              textStyle: TextStyle(
+                color: Colors.black, 
+                letterSpacing: .5, 
+                fontSize: 14.0, 
+              )
+            )
+          )
+        ) : Bubble(
+          nip: isSent ? BubbleNip.rightTop : BubbleNip.leftTop,
+          nipOffset: 0.0,
+          style: BubbleStyle(
+            margin: isSent ? 
+              BubbleEdges.fromLTRB(50.0, 10.0, 10.0, 10.0) :
+              BubbleEdges.fromLTRB(10.0, 10.0, 50.0, 10.0),
+            padding: BubbleEdges.all(10.0),
+            color: isSent ? Theme.of(context).accentColor : Colors.grey,
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.all(Radius.circular(8.0)),
+            child: CachedNetworkImage(
+              imageUrl: message,
+              fit: BoxFit.fill,
+              placeholder: (context, url) => Container(
+                width: 200.0,
+                height: 200.0,
+                padding: EdgeInsets.all(70.0),
+                child: CircularProgressIndicator(
+                  valueColor: AlwaysStoppedAnimation<Color>(Colors.white)
+                )
+              ),
+              errorWidget: (context, url, error) => Text("error"),
             )
           )
         )
-      ) : Container(
-        decoration: BoxDecoration(
-          color: isSent ? Theme.of(context).accentColor : Colors.grey,
-          borderRadius: BorderRadius.all(Radius.circular(8.0)),
-        ),
-        margin: isSent ? 
-          EdgeInsets.fromLTRB(50.0, 10.0, 10.0, 10.0) :
-          EdgeInsets.fromLTRB(10.0, 10.0, 50.0, 10.0),
-        child: ClipRRect(
-          borderRadius: BorderRadius.all(Radius.circular(8.0)),
-          child: CachedNetworkImage(
-            imageUrl: message,
-            fit: BoxFit.fill,
-            placeholder: (context, url) => Container(
-              width: 200.0,
-              height: 200.0,
-              padding: EdgeInsets.all(70.0),
-              child: CircularProgressIndicator(
-                valueColor: AlwaysStoppedAnimation<Color>(Colors.white)
-              )
-            ),
-            errorWidget: (context, url, error) => Text("error"),
-          )
-        )
-      )
     );
   }
 }

--- a/lib/chat/new_matches.dart
+++ b/lib/chat/new_matches.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:redux/redux.dart';
 
 import '../common/format_text.dart';
-import '../constants/chat_constants.dart';
 import '../models/models.dart';
 import '../selectors/selectors.dart';
 import './chat_messenger.dart';
@@ -35,14 +34,6 @@ class _NewMatchesState extends State<NewMatches> {
 
     return Column(
       children: <Widget>[
-        Padding(
-          padding: EdgeInsets.only(top: 20, bottom: 10),
-          child: FormatText(
-            text: chatNewMatchesTitle,
-            textAlign: TextAlign.left,
-            fontSize: 18.0,
-          )
-        ),
         buildNewMatches(
           context, 
           widget.newMatchesList, 
@@ -104,10 +95,27 @@ buildNewMatches(context, newMatchesList, id, isMentee) {
     );
   }
 
-  return SingleChildScrollView(
-    scrollDirection: Axis.horizontal,
+  return Container(
+    width: MediaQuery.of(context).size.width,
     child: Row(
-      children: newMatchesWidgetList,
+      children: <Widget>[
+        Container(
+          child: Column(
+            children: <Widget>[
+              Image.asset('images/onboarding/ano_standing.png', height: 60.0),
+              Container(height: 1.5, width: 50, color: Colors.black),
+            ]
+          ),
+        ),
+        Expanded(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: newMatchesWidgetList,
+            )
+          )
+        )
+      ]
     )
   );
 }

--- a/lib/chat/new_matches.dart
+++ b/lib/chat/new_matches.dart
@@ -6,6 +6,7 @@ import '../common/format_text.dart';
 import '../models/models.dart';
 import '../selectors/selectors.dart';
 import './chat_messenger.dart';
+import './common/profile_picture.dart';
 
 class NewMatches extends StatefulWidget {
   final List<Match> newMatchesList;
@@ -70,13 +71,9 @@ buildNewMatches(context, newMatchesList, id, isMentee) {
           color: Colors.transparent,
           child: Column(
             children: <Widget>[
-              Container(
-                width: 60.0, 
-                height: 60.0, 
-                decoration: BoxDecoration(
-                  color: Colors.black, 
-                  shape: BoxShape.circle
-                )
+              ProfilePicture(
+                containerSideLength: 60.0, 
+                profilePictureRadius: 60.0
               ),
               Flexible(
                 child: FormatText(

--- a/lib/chat/user_message_rows.dart
+++ b/lib/chat/user_message_rows.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:redux/redux.dart';
 
 import '../common/format_text.dart';
@@ -36,21 +37,6 @@ class _UserMessageRowsState extends State<UserMessageRows> {
 
     return Column(
       children: <Widget>[
-        Padding (
-          padding: EdgeInsets.only(top: 20, bottom: 10),
-          child:Text(
-            chatMessageRowTitle, 
-            textAlign: TextAlign.left,
-            style: GoogleFonts.muli(
-              textStyle: TextStyle(
-                color: Colors.black, 
-                letterSpacing: .5, 
-                fontSize: 18.0, 
-                fontWeight: FontWeight.bold
-              )
-            )
-          )
-        ),
         buildMessageRows(
           context, 
           widget.matchesList, 
@@ -73,6 +59,7 @@ buildMessageRows(
     var lastMessage = match.lastMessage;
     var lastMessageType = lastMessage.type;
     var isSent = lastMessage.idFrom == id;
+    var isRead = !isSent && lastMessage.isRead == true;
     var recipient = isMentee == true ? match.mentor : match.mentee;
     messagesList.add(
       GestureDetector(
@@ -90,65 +77,100 @@ buildMessageRows(
             )
           );
         },
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisSize: MainAxisSize.max, 
-          children: <Widget>[
-            Container(
-              width: 80.0,
-              height: 80.0,
-              child: Center(
-                child: Container(
-                  width: 60.0, 
-                  height: 60.0, 
-                  decoration: BoxDecoration(
-                    color: Colors.black, 
-                    shape: BoxShape.circle
+        child: Container(
+          margin: EdgeInsets.fromLTRB(30.0, 15.0, 30.0, 15.0),
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: isRead || isSent ? 
+                Colors.grey : 
+                Theme.of(context).accentColor, 
+              width: 1.0
+            ),
+            borderRadius: BorderRadius.all(Radius.circular(15.0)),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisSize: MainAxisSize.max, 
+            children: <Widget>[
+              Container(
+                width: 80.0,
+                height: 80.0,
+                child: Center(
+                  child: Container(
+                    width: 60.0, 
+                    height: 60.0, 
+                    decoration: BoxDecoration(
+                      color: Colors.black, 
+                      shape: BoxShape.circle
+                    )
                   )
                 )
-              )
-            ),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  FormatText(
-                    text: recipient.fullName,
-                    fontSize: 14.0,
-                  ),
-                  RichText(
-                    overflow: TextOverflow.ellipsis,
-                    text: TextSpan(
-                      style: GoogleFonts.muli(
-                        textStyle: TextStyle(
-                          color: Colors.grey,
-                          letterSpacing: .5, 
-                          fontSize: 12.0, 
-                        )
-                      ),
-                      children: [
-                        if(isSent != false) WidgetSpan(
-                          child: Container(
-                            margin: EdgeInsets.only(right: 6.0),
-                            child: Icon(
-                              Icons.send, 
-                              size: 12, 
-                              color: Colors.grey
-                            )
-                          ),
+              ),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: <Widget>[
+                        FormatText(
+                          text: recipient.fullName,
+                          fontSize: 14.0,
                         ),
-                        TextSpan(
-                          text: lastMessageType == 0 ? 
-                            lastMessage.content : 
-                            imageMessageDesciption
+                        Container(
+                          padding: EdgeInsets.only(right: 10.0),
+                          child: FormatText(
+                            text: DateFormat('jm').format(
+                              DateTime.fromMillisecondsSinceEpoch(
+                                int.parse(lastMessage.timestamp)
+                              )
+                            ),
+                            fontSize: 14.0,
+                            fontWeight: FontWeight.w400,
+                            textColor: Colors.grey,
+                          )
                         )
-                      ]
+                      ],
                     ),
-                  )
-                ]
+                    RichText(
+                      overflow: TextOverflow.ellipsis,
+                      text: TextSpan(
+                        style: GoogleFonts.muli(
+                          textStyle: TextStyle(
+                            color: Colors.grey,
+                            letterSpacing: .5, 
+                            fontSize: 12.0, 
+                          )
+                        ),
+                        children: [
+                          if(isSent != false) WidgetSpan(
+                            child: Container(
+                              margin: EdgeInsets.only(right: 6.0),
+                              child: Icon(
+                                Icons.send, 
+                                size: 12, 
+                                color: Colors.grey
+                              )
+                            ),
+                          ),
+                          TextSpan(
+                            style: TextStyle(
+                              color: isRead || isSent ? 
+                                Colors.grey : 
+                                Theme.of(context).accentColor,
+                            ),
+                            text: lastMessageType == 0 ? 
+                              lastMessage.content : 
+                              imageMessageDesciption
+                          )
+                        ]
+                      ),
+                    )
+                  ]
+                )
               )
-            )
-          ]
+            ]
+          )
         )
       )
     );

--- a/lib/chat/user_message_rows.dart
+++ b/lib/chat/user_message_rows.dart
@@ -1,14 +1,10 @@
 import 'package:flutter_redux/flutter_redux.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:redux/redux.dart';
 
-import '../common/format_text.dart';
-import '../constants/chat_constants.dart';
 import '../models/models.dart';
 import '../selectors/selectors.dart';
-import './chat_messenger.dart';
+import './common/message_row.dart';
 
 class UserMessageRows extends StatefulWidget {
   final List<Match> matchesList;
@@ -56,122 +52,12 @@ buildMessageRows(
 ) {
   var messagesList = <Widget>[];
   for (var match in matchesList) {
-    var lastMessage = match.lastMessage;
-    var lastMessageType = lastMessage.type;
-    var isSent = lastMessage.idFrom == id;
-    var isRead = !isSent && lastMessage.isRead == true;
     var recipient = isMentee == true ? match.mentor : match.mentee;
     messagesList.add(
-      GestureDetector(
-        behavior: HitTestBehavior.translucent,
-        onTap: () {
-          Navigator.push(
-            context, 
-            MaterialPageRoute(builder: (context) => 
-              ChatMessenger(
-              recipient: recipient.fullName, 
-                peerId: recipient.id, 
-                id: id,
-                groupChatId: match.matchId,
-              )
-            )
-          );
-        },
-        child: Container(
-          margin: EdgeInsets.fromLTRB(30.0, 15.0, 30.0, 15.0),
-          decoration: BoxDecoration(
-            border: Border.all(
-              color: isRead || isSent ? 
-                Colors.grey : 
-                Theme.of(context).accentColor, 
-              width: 1.0
-            ),
-            borderRadius: BorderRadius.all(Radius.circular(15.0)),
-          ),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            mainAxisSize: MainAxisSize.max, 
-            children: <Widget>[
-              Container(
-                width: 80.0,
-                height: 80.0,
-                child: Center(
-                  child: Container(
-                    width: 60.0, 
-                    height: 60.0, 
-                    decoration: BoxDecoration(
-                      color: Colors.black, 
-                      shape: BoxShape.circle
-                    )
-                  )
-                )
-              ),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: <Widget>[
-                        FormatText(
-                          text: recipient.fullName,
-                          fontSize: 14.0,
-                        ),
-                        Container(
-                          padding: EdgeInsets.only(right: 10.0),
-                          child: FormatText(
-                            text: DateFormat('jm').format(
-                              DateTime.fromMillisecondsSinceEpoch(
-                                int.parse(lastMessage.timestamp)
-                              )
-                            ),
-                            fontSize: 14.0,
-                            fontWeight: FontWeight.w400,
-                            textColor: Colors.grey,
-                          )
-                        )
-                      ],
-                    ),
-                    RichText(
-                      overflow: TextOverflow.ellipsis,
-                      text: TextSpan(
-                        style: GoogleFonts.muli(
-                          textStyle: TextStyle(
-                            color: Colors.grey,
-                            letterSpacing: .5, 
-                            fontSize: 12.0, 
-                          )
-                        ),
-                        children: [
-                          if(isSent != false) WidgetSpan(
-                            child: Container(
-                              margin: EdgeInsets.only(right: 6.0),
-                              child: Icon(
-                                Icons.send, 
-                                size: 12, 
-                                color: Colors.grey
-                              )
-                            ),
-                          ),
-                          TextSpan(
-                            style: TextStyle(
-                              color: isRead || isSent ? 
-                                Colors.grey : 
-                                Theme.of(context).accentColor,
-                            ),
-                            text: lastMessageType == 0 ? 
-                              lastMessage.content : 
-                              imageMessageDesciption
-                          )
-                        ]
-                      ),
-                    )
-                  ]
-                )
-              )
-            ]
-          )
-        )
+      MessageRow(
+        recipient: recipient,
+        match: match,
+        id: id
       )
     );
   }

--- a/lib/constants/chat_constants.dart
+++ b/lib/constants/chat_constants.dart
@@ -6,6 +6,8 @@ const String chatNewMatchesTitle = "New Matches";
 
 const String imageMessageDesciption = "Sent an image message";
 
+const String keyboardInputHintText = 'Send a message...';
+
 const int textMessage = 0;
 const int imageMessage = 1;
 

--- a/lib/models/entities/message.dart
+++ b/lib/models/entities/message.dart
@@ -8,6 +8,7 @@ class Message {
   final String idTo;
   final String idFrom;
   final String content;
+  final bool isRead;
 
   const Message({
     @required this.type,
@@ -15,6 +16,7 @@ class Message {
     @required this.idTo,
     @required this.idFrom,
     @required this.content,
+    @required this.isRead,
   });
 
   factory Message.initial() {
@@ -23,7 +25,8 @@ class Message {
       timestamp: DateTime.now().millisecondsSinceEpoch.toString(),
       idTo: '',
       idFrom: '',
-      content: ''
+      content: '',
+      isRead: false,
     );
   }
 
@@ -33,6 +36,7 @@ class Message {
     String idTo,
     String idFrom,
     String content,
+    bool isRead,
   }) {
     return Message(
       type: type ?? this.type,
@@ -40,6 +44,7 @@ class Message {
       idTo: idTo ?? this.idTo,
       idFrom: idFrom ?? this.idFrom,
       content: content ?? this.content,
+      isRead: isRead ?? this.isRead,
     );
   }
 
@@ -51,6 +56,7 @@ class Message {
         idTo: json["idTo"] as String,
         idFrom: json["idFrom"] as String,
         content: json["content"] as String,
+        isRead: json["isRead"] as bool,
       );
     }
     return null;
@@ -62,6 +68,7 @@ class Message {
     'idTo': idTo,
     'idFrom': idFrom,
     'content': content,
+    'isRead': isRead,
   };
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,6 +50,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  bubble:
+    dependency: "direct main"
+    description:
+      name: bubble
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.9"
   cached_network_image:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
     sdk: flutter
 
   auto_size_text: ^2.1.0
+  bubble: ^1.1.9
   cached_network_image: ^2.0.0
   cupertino_icons: ^0.1.2         
   custom_navigation_bar: ^0.2.6


### PR DESCRIPTION
**Changes**
- change the chat UI to match mockups

**Known Bugs/Differences from mockups to be addressed later**
- bubble.dart does not allow for outlines, this means that the chat bubbles were filled in with colour rather than just outlined. We may need to make a custom bubble class to fix this
- Several logos are different than the mockup, waiting for the logos from @laiiibah 
- The user profile picture was moved to above the user name
- The new match's ano is the incorrect ano, waiting for the correct ano from @laiiibah 
- The bracket is missing from the top right of the chat
- The new matches should have a horizontal fade in/fade out to prevent the harsh clipping against the ano

**UI**
> ![Screen Shot 2020-07-29 at 3 19 51 PM](https://user-images.githubusercontent.com/43127491/88854832-29dc3200-d1af-11ea-91da-beb14d88230c.png)
> ![Screen Shot 2020-07-29 at 3 20 00 PM](https://user-images.githubusercontent.com/43127491/88854839-2ba5f580-d1af-11ea-80b5-380919a27712.png)


