### PR TITLE
fix: position of card footer buttons + update constant naming

### DIFF
--- a/lib/constants/pairings_constants.dart
+++ b/lib/constants/pairings_constants.dart
@@ -1,4 +1,4 @@
-const String readMoreAction = 'Read more';
+const String readMoreButtonText = 'Read more';
 
 const dummyCard = {
   "name": "Helen Gezahegn", 

--- a/lib/pairings/pairings.dart
+++ b/lib/pairings/pairings.dart
@@ -98,13 +98,10 @@ class Pairings extends StatelessWidget {
   }
 
   Widget buildCurrentCard(context) {
-    var sidePadding = screenWidth * 0.05;
     return Padding(
-      padding: EdgeInsets.only(
-        top: screenHeight * 0.02, 
-        left: sidePadding, 
-        right: sidePadding,
-        bottom: screenHeight * 0.02,
+      padding: EdgeInsets.symmetric(
+        vertical: screenHeight * 0.02, 
+        horizontal: screenWidth * 0.05
       ),
       child: Column(
         children: [

--- a/lib/pairings/pairings.dart
+++ b/lib/pairings/pairings.dart
@@ -21,10 +21,7 @@ class Pairings extends StatelessWidget {
       body: Column(
         children: [
           buildAno(),
-          Align(
-            alignment: Alignment.center, 
-            child: buildCards(context)
-          )
+          buildCards(context)
         ]
       )
     );
@@ -41,7 +38,7 @@ class Pairings extends StatelessWidget {
   PrimaryButton buildReadMoreButton() {
     return PrimaryButton(
       isLight: true,
-      text: readMoreAction,
+      text: readMoreButtonText,
       onPressed: () => print("Read more pressed")
     );
   }
@@ -73,7 +70,7 @@ class Pairings extends StatelessWidget {
   FormatText buildCardBody() {
     return FormatText(
       text: dummyCard["description"], 
-      fontSize: 14.0,
+      fontSize: 12.0,
       fontWeight: FontWeight.w300,
       fontHeight: 1.6
     );
@@ -83,15 +80,13 @@ class Pairings extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        SizedBox(
-          width: screenWidth * 0.11, 
-          height: screenHeight * 0.10, 
-          child: FlatButton(
-            padding: EdgeInsets.all(0.0),
-            child: Image.asset("images/right_arrow.png"), 
-            onPressed: () => print("Arrow pressed")
+        InkWell(
+          onTap: () => print("Arrow pressed"),
+          child: Image.asset(
+            'images/right_arrow.png', 
+            height: screenHeight * 0.015
           )
-        ), 
+        ),
         IconButton(
           icon: Icon(Icons.favorite),
           iconSize: screenHeight * 0.03, 
@@ -108,12 +103,14 @@ class Pairings extends StatelessWidget {
       padding: EdgeInsets.only(
         top: screenHeight * 0.02, 
         left: sidePadding, 
-        right: sidePadding
+        right: sidePadding,
+        bottom: screenHeight * 0.02,
       ),
       child: Column(
         children: [
           buildCardHeader(),
           buildCardBody(), 
+          Spacer(), 
           buildCardFooter(context)
         ]
       )
@@ -133,21 +130,24 @@ class Pairings extends StatelessWidget {
     );
   }
 
-  Container buildCards(context) {
-    return Container(
-      width: screenWidth * 0.80,
-      height: screenHeight * 0.42,
-      decoration: buildCardContainer(context), 
-      child: Stack(
-        overflow: Overflow.visible, 
-        alignment: Alignment.center, 
-        children: [
-          buildCurrentCard(context), 
-          Positioned(
-            top: screenHeight * 0.38, 
-            child: buildReadMoreButton()
-          )
-        ]
+  Widget buildCards(context) {
+    return Align(
+      alignment: Alignment.center, 
+      child: Container(
+        width: screenWidth * 0.80,
+        height: screenHeight * 0.42,
+        decoration: buildCardContainer(context), 
+        child: Stack(
+          overflow: Overflow.visible, 
+          alignment: Alignment.center, 
+          children: [
+            buildCurrentCard(context), 
+            Positioned(
+              top: screenHeight * 0.39, 
+              child: buildReadMoreButton()
+            )
+          ]
+        )
       )
     );
   }


### PR DESCRIPTION
**Changes**
- rename `readMoreAction` to `readMoreActionButtonText`
- converted `FlatButton` to `InkWell` for pairings arrow button
- cleaned-up `pairings.dart`


**UI**
> iPhone SE
> <img src="https://user-images.githubusercontent.com/23146829/89132232-fca1c380-d4cf-11ea-8a1b-1d1c40e35ad4.png" width="350px" /> 

> iPhone 11 Pro
> <img src="https://user-images.githubusercontent.com/23146829/89132247-0f1bfd00-d4d0-11ea-9518-e1c41d70f5f9.png" width="350px" />

> iPad
> <img src="https://user-images.githubusercontent.com/23146829/89132253-222ecd00-d4d0-11ea-8430-929c3ab6e5c7.png" width="350px" />
