### PR TITLE
feat: common context for screen size + theme colors

### DIFF
--- a/lib/authentication/login.dart
+++ b/lib/authentication/login.dart
@@ -220,7 +220,7 @@ class _Login extends State<Login> {
       child: FormBuilderTextField(
         attribute: 'emailAddress',
         focusNode: emailAddressFocus,
-        style: fieldTextStyle(color: Theme.of(context).primaryColor),
+        style: fieldTextStyle(color: ThemeColors.primary),
         decoration: fieldDecoration(
           context,
           isFocused: isEmailAddressFocused,
@@ -247,7 +247,7 @@ class _Login extends State<Login> {
         focusNode: passwordFocus,
         obscureText: true,
         maxLines: 1,
-        style: fieldTextStyle(color: Theme.of(context).primaryColor),
+        style: fieldTextStyle(color: ThemeColors.primary),
         decoration: fieldDecoration(
           context,
           isFocused: isPasswordFocused,
@@ -289,7 +289,7 @@ class _Login extends State<Login> {
         ),
         child: FormatText(
           text: forgotPassword,
-          textColor: Theme.of(context).accentColor,
+          textColor: ThemeColors.accent,
           fontSize: 14.0,
           fontWeight: FontWeight.w500,
         )

--- a/lib/authentication/login.dart
+++ b/lib/authentication/login.dart
@@ -36,7 +36,6 @@ class _Login extends State<Login> {
   bool isEmailAddressInvalid, isPasswordInvalid;
   bool isLoading;
   Store<AppState> store;
-  double screenHeight, screenWidth;
 
   @override
   void initState() {
@@ -64,9 +63,7 @@ class _Login extends State<Login> {
 
   @override
   Widget build(BuildContext context) {
-
-    screenWidth = MediaQuery.of(context).size.width;
-    screenHeight = MediaQuery.of(context).size.height;
+    CommonContext().init(context);
 
     return Scaffold(
       backgroundColor: Colors.white,
@@ -167,15 +164,15 @@ class _Login extends State<Login> {
       alignment: Alignment.center,
       children: <Widget>[
         Positioned(
-          top: screenHeight * 0.15,
+          top: ScreenSize.screenHeight * 0.15,
           child: buildCenterAno()
         ),
         Positioned(
-          top: screenHeight * 0.35,
+          top: ScreenSize.screenHeight * 0.35,
           child: buildForm()
         ),
         Positioned(
-          bottom: screenHeight * 0.05,
+          bottom: ScreenSize.screenHeight * 0.05,
           child: FooterLinks()
         )
       ]
@@ -184,7 +181,7 @@ class _Login extends State<Login> {
 
   Widget buildForm() {
     return Container(
-      width: screenWidth * 0.60,
+      width: ScreenSize.screenWidth * 0.60,
       child: FormBuilder(
         key: _loginFormKey,
         child: Column(
@@ -201,12 +198,12 @@ class _Login extends State<Login> {
 
   Widget buildCenterAno() {
     return Container(
-      width: screenWidth,
+      width: ScreenSize.screenWidth,
       child: Column(
         children: <Widget>[
           SvgPicture.asset(
             'images/diverse_ano.svg',
-            height: screenHeight * 0.11,
+            height: ScreenSize.screenHeight * 0.11,
           ),
           Container(
             height: 1.5,
@@ -271,7 +268,7 @@ class _Login extends State<Login> {
   Widget buildLoginButton() {
     return Container(
       padding: EdgeInsets.only(
-        top: screenHeight * 0.10
+        top: ScreenSize.screenHeight * 0.10
       ),
       child: PrimaryButton(
         isLight: true,

--- a/lib/authentication/login.dart
+++ b/lib/authentication/login.dart
@@ -164,15 +164,15 @@ class _Login extends State<Login> {
       alignment: Alignment.center,
       children: <Widget>[
         Positioned(
-          top: ScreenSize.screenHeight * 0.15,
+          top: ScreenSize.height * 0.15,
           child: buildCenterAno()
         ),
         Positioned(
-          top: ScreenSize.screenHeight * 0.35,
+          top: ScreenSize.height * 0.35,
           child: buildForm()
         ),
         Positioned(
-          bottom: ScreenSize.screenHeight * 0.05,
+          bottom: ScreenSize.height * 0.05,
           child: FooterLinks()
         )
       ]
@@ -181,7 +181,7 @@ class _Login extends State<Login> {
 
   Widget buildForm() {
     return Container(
-      width: ScreenSize.screenWidth * 0.60,
+      width: ScreenSize.width * 0.60,
       child: FormBuilder(
         key: _loginFormKey,
         child: Column(
@@ -198,12 +198,12 @@ class _Login extends State<Login> {
 
   Widget buildCenterAno() {
     return Container(
-      width: ScreenSize.screenWidth,
+      width: ScreenSize.width,
       child: Column(
         children: <Widget>[
           SvgPicture.asset(
             'images/diverse_ano.svg',
-            height: ScreenSize.screenHeight * 0.11,
+            height: ScreenSize.height * 0.11,
           ),
           Container(
             height: 1.5,
@@ -268,7 +268,7 @@ class _Login extends State<Login> {
   Widget buildLoginButton() {
     return Container(
       padding: EdgeInsets.only(
-        top: ScreenSize.screenHeight * 0.10
+        top: ScreenSize.height * 0.10
       ),
       child: PrimaryButton(
         isLight: true,

--- a/lib/authentication/login_signup_funnel.dart
+++ b/lib/authentication/login_signup_funnel.dart
@@ -17,12 +17,12 @@ class LoginSignupFunnel extends StatelessWidget {
     return Scaffold(
       backgroundColor: Colors.white,
       body: Container(
-        width: ScreenSize.screenWidth,
+        width: ScreenSize.width,
         child: Stack(
           alignment: Alignment.center,
           children: <Widget>[
              Positioned(
-              top: ScreenSize.screenHeight * 0.15,
+              top: ScreenSize.height * 0.15,
               child: buildTitle(context)
             ),
             Column(
@@ -33,7 +33,7 @@ class LoginSignupFunnel extends StatelessWidget {
               ]
             ),
             Positioned(
-              bottom: ScreenSize.screenHeight * 0.05,
+              bottom: ScreenSize.height * 0.05,
               child: FooterLinks()
             )
           ]
@@ -72,12 +72,12 @@ class LoginSignupFunnel extends StatelessWidget {
   Widget buildCenterLogo() {
     return Container(
       padding: EdgeInsets.only(
-        top: ScreenSize.screenHeight * 0.40
+        top: ScreenSize.height * 0.40
       ),
       child: SvgPicture.asset(
         'images/dark_logo.svg',
-        height: ScreenSize.screenHeight * 0.15,
-        width: ScreenSize.screenHeight * 0.15,
+        height: ScreenSize.height * 0.15,
+        width: ScreenSize.height * 0.15,
       )
     );
   }
@@ -85,7 +85,7 @@ class LoginSignupFunnel extends StatelessWidget {
   Widget buildLoginButton(BuildContext context) {
     return Container(
       padding: EdgeInsets.only(
-        top: ScreenSize.screenHeight * 0.20
+        top: ScreenSize.height * 0.20
       ),
       child: PrimaryButton(
         text: loginButtonText,

--- a/lib/authentication/login_signup_funnel.dart
+++ b/lib/authentication/login_signup_funnel.dart
@@ -47,7 +47,7 @@ class LoginSignupFunnel extends StatelessWidget {
       children: <Widget>[
         FormatText(
           text: appName,
-          textColor: ThemeColors.primaryColor,
+          textColor: ThemeColors.primary,
           fontSize: 50.0,
           fontWeight: FontWeight.w700,
         ),
@@ -61,7 +61,7 @@ class LoginSignupFunnel extends StatelessWidget {
       padding: EdgeInsets.only(top: 5.0),
       child: FormatText(
         text: getStartedSubTitle,
-        textColor: ThemeColors.primaryColor,
+        textColor: ThemeColors.primary,
         fontSize: 14.0,
         fontWeight: FontWeight.w500,
       )

--- a/lib/authentication/login_signup_funnel.dart
+++ b/lib/authentication/login_signup_funnel.dart
@@ -12,29 +12,28 @@ class LoginSignupFunnel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var screenWidth = MediaQuery.of(context).size.width;
-    var screenHeight = MediaQuery.of(context).size.height;
-
+    CommonContext().init(context);
+    
     return Scaffold(
       backgroundColor: Colors.white,
       body: Container(
-        width: screenWidth,
+        width: ScreenSize.screenWidth,
         child: Stack(
           alignment: Alignment.center,
           children: <Widget>[
              Positioned(
-              top: screenHeight * 0.15,
+              top: ScreenSize.screenHeight * 0.15,
               child: buildTitle(context)
             ),
             Column(
               children: <Widget>[
-                buildCenterLogo(screenHeight),
-                buildLoginButton(context, screenHeight),
+                buildCenterLogo(),
+                buildLoginButton(context),
                 buildCreateAccountButton(context),
               ]
             ),
             Positioned(
-              bottom: screenHeight * 0.05,
+              bottom: ScreenSize.screenHeight * 0.05,
               child: FooterLinks()
             )
           ]
@@ -48,21 +47,21 @@ class LoginSignupFunnel extends StatelessWidget {
       children: <Widget>[
         FormatText(
           text: appName,
-          textColor: Theme.of(context).primaryColor,
+          textColor: ThemeColors.primaryColor,
           fontSize: 50.0,
           fontWeight: FontWeight.w700,
         ),
-        buildSubTitle(context)
+        buildSubTitle()
       ]
     );
   }
 
-  Widget buildSubTitle(BuildContext context) {
+  Widget buildSubTitle() {
     return  Container(
       padding: EdgeInsets.only(top: 5.0),
       child: FormatText(
         text: getStartedSubTitle,
-        textColor: Theme.of(context).primaryColor,
+        textColor: ThemeColors.primaryColor,
         fontSize: 14.0,
         fontWeight: FontWeight.w500,
       )
@@ -70,23 +69,23 @@ class LoginSignupFunnel extends StatelessWidget {
   }
 
   // TODO: Change when mockup svgs are available
-  Widget buildCenterLogo(double screenHeight) {
+  Widget buildCenterLogo() {
     return Container(
       padding: EdgeInsets.only(
-        top: screenHeight * 0.40
+        top: ScreenSize.screenHeight * 0.40
       ),
       child: SvgPicture.asset(
         'images/dark_logo.svg',
-        height: screenHeight * 0.15,
-        width: screenHeight * 0.15,
+        height: ScreenSize.screenHeight * 0.15,
+        width: ScreenSize.screenHeight * 0.15,
       )
     );
   }
 
-  Widget buildLoginButton(BuildContext context, double screenHeight) {
+  Widget buildLoginButton(BuildContext context) {
     return Container(
       padding: EdgeInsets.only(
-        top: screenHeight * 0.20
+        top: ScreenSize.screenHeight * 0.20
       ),
       child: PrimaryButton(
         text: loginButtonText,
@@ -99,6 +98,7 @@ class LoginSignupFunnel extends StatelessWidget {
       )
     );
   }
+  
   Widget buildCreateAccountButton(BuildContext context) {
     return Container(
       padding: EdgeInsets.only(top: 5.0),

--- a/lib/authentication/password/link_sent.dart
+++ b/lib/authentication/password/link_sent.dart
@@ -26,13 +26,9 @@ class _LinkSent extends State<LinkSent> {
   final GlobalKey<FormBuilderState> _disabledEmailAddressFormKey
     = GlobalKey<FormBuilderState>();
 
-  double screenHeight, screenWidth;
-
   @override
   Widget build(BuildContext context) {
-
-    screenWidth = MediaQuery.of(context).size.width;
-    screenHeight = MediaQuery.of(context).size.height;
+    CommonContext().init(context);
 
     return Scaffold(
       backgroundColor: Colors.white,
@@ -53,11 +49,11 @@ class _LinkSent extends State<LinkSent> {
       alignment: Alignment.center,
       children: <Widget>[
         Positioned(
-          top: screenHeight * 0.15,
+          top: ScreenSize.screenHeight * 0.15,
           child: buildCenterAno()
         ),
         Positioned(
-          top: screenHeight * 0.35,
+          top: ScreenSize.screenHeight * 0.35,
           child: buildForm()
         ),
         buildReminderSection(),
@@ -68,7 +64,7 @@ class _LinkSent extends State<LinkSent> {
 
   Widget buildForm() {
     return Container(
-      width: screenWidth * 0.60,
+      width: ScreenSize.screenWidth * 0.60,
       child: FormBuilder(
         key: _disabledEmailAddressFormKey,
         child: Column(
@@ -82,12 +78,12 @@ class _LinkSent extends State<LinkSent> {
 
   Widget buildCenterAno() {
     return Container(
-      width: screenWidth,
+      width: ScreenSize.screenWidth,
       child: Column(
         children: <Widget>[
           Image.asset(
             'images/sign_up/ano_hands_side.png',
-            height: screenHeight * 0.11
+            height: ScreenSize.screenHeight * 0.11
           ),
           Container(
             height: 1.5,
@@ -120,7 +116,7 @@ class _LinkSent extends State<LinkSent> {
 
   Widget buildReminderSection() {
     return Positioned(
-      top: screenHeight * 0.50,
+      top: ScreenSize.screenHeight * 0.50,
       child: Column(
         children: <Widget>[
           buildLinkSentInfoBorder(),
@@ -150,7 +146,7 @@ class _LinkSent extends State<LinkSent> {
 
   Widget buildFooter() {
     return Positioned(
-      bottom: screenHeight * 0.05,
+      bottom: ScreenSize.screenHeight * 0.05,
       child: Row(
         children: <Widget>[
           buildFooterText(),

--- a/lib/authentication/password/link_sent.dart
+++ b/lib/authentication/password/link_sent.dart
@@ -49,11 +49,11 @@ class _LinkSent extends State<LinkSent> {
       alignment: Alignment.center,
       children: <Widget>[
         Positioned(
-          top: ScreenSize.screenHeight * 0.15,
+          top: ScreenSize.height * 0.15,
           child: buildCenterAno()
         ),
         Positioned(
-          top: ScreenSize.screenHeight * 0.35,
+          top: ScreenSize.height * 0.35,
           child: buildForm()
         ),
         buildReminderSection(),
@@ -64,7 +64,7 @@ class _LinkSent extends State<LinkSent> {
 
   Widget buildForm() {
     return Container(
-      width: ScreenSize.screenWidth * 0.60,
+      width: ScreenSize.width * 0.60,
       child: FormBuilder(
         key: _disabledEmailAddressFormKey,
         child: Column(
@@ -78,12 +78,12 @@ class _LinkSent extends State<LinkSent> {
 
   Widget buildCenterAno() {
     return Container(
-      width: ScreenSize.screenWidth,
+      width: ScreenSize.width,
       child: Column(
         children: <Widget>[
           Image.asset(
             'images/sign_up/ano_hands_side.png',
-            height: ScreenSize.screenHeight * 0.11
+            height: ScreenSize.height * 0.11
           ),
           Container(
             height: 1.5,
@@ -116,7 +116,7 @@ class _LinkSent extends State<LinkSent> {
 
   Widget buildReminderSection() {
     return Positioned(
-      top: ScreenSize.screenHeight * 0.50,
+      top: ScreenSize.height * 0.50,
       child: Column(
         children: <Widget>[
           buildLinkSentInfoBorder(),
@@ -146,7 +146,7 @@ class _LinkSent extends State<LinkSent> {
 
   Widget buildFooter() {
     return Positioned(
-      bottom: ScreenSize.screenHeight * 0.05,
+      bottom: ScreenSize.height * 0.05,
       child: Row(
         children: <Widget>[
           buildFooterText(),

--- a/lib/authentication/password/link_sent.dart
+++ b/lib/authentication/password/link_sent.dart
@@ -131,7 +131,7 @@ class _LinkSent extends State<LinkSent> {
       padding: EdgeInsets.only(top: 15.0),
       child: FormatText(
         text: widget.resetLinkSent ? resetLinkSentInfoText : linkSentInfoText,
-        textColor: Theme.of(context).primaryColor,
+        textColor: ThemeColors.primary,
         fontSize: 14.0,
         fontWeight: FontWeight.w500,
       )
@@ -159,7 +159,7 @@ class _LinkSent extends State<LinkSent> {
   Widget buildFooterText() {
     return FormatText(
       text: linkSentFooterText,
-      textColor: Theme.of(context).primaryColor,
+      textColor: ThemeColors.primary,
       fontSize: 14.0,
       fontWeight: FontWeight.w500,
     );
@@ -170,7 +170,7 @@ class _LinkSent extends State<LinkSent> {
       onTap: () => Auth().sendEmailVerification(),
       child: FormatText(
         text: linkSentFooterLink,
-        textColor: Theme.of(context).accentColor,
+        textColor: ThemeColors.accent,
         fontSize: 14.0,
         fontWeight: FontWeight.w500,
       )

--- a/lib/authentication/password/reset_link.dart
+++ b/lib/authentication/password/reset_link.dart
@@ -20,7 +20,6 @@ class _ResetLink extends State<ResetLink> {
   final GlobalKey<FormBuilderState> _emailAddressFormKey
     = GlobalKey<FormBuilderState>();
 
-  double screenHeight, screenWidth;
   bool isLoading, isEmailAddressInvalid;
   String emailAddress;
 
@@ -35,9 +34,7 @@ class _ResetLink extends State<ResetLink> {
 
   @override
   Widget build(BuildContext context) {
-
-    screenWidth = MediaQuery.of(context).size.width;
-    screenHeight = MediaQuery.of(context).size.height;
+    CommonContext().init(context);
 
     return Scaffold(
       backgroundColor: Colors.white,
@@ -58,15 +55,15 @@ class _ResetLink extends State<ResetLink> {
       alignment: Alignment.center,
       children: <Widget>[
         Positioned(
-          top: screenHeight * 0.15,
+          top: ScreenSize.screenHeight * 0.15,
           child: buildCenterAno()
         ),
         Positioned(
-          top: screenHeight * 0.35,
+          top: ScreenSize.screenHeight * 0.35,
           child: buildForm()
         ), 
         Positioned(
-          top: screenHeight * 0.50,
+          top: ScreenSize.screenHeight * 0.50,
           child: buildResetLinkButton()
         )
       ]
@@ -75,12 +72,12 @@ class _ResetLink extends State<ResetLink> {
 
  Widget buildCenterAno() {
     return Container(
-      width: screenWidth,
+      width: ScreenSize.screenWidth,
       child: Column(
         children: <Widget>[
           Image.asset(
             'images/sign_up/ano_hands_straight_up.png', 
-            height: screenHeight * 0.11
+            height: ScreenSize.screenHeight * 0.11
           ),
           Container(
             height: 1.5,
@@ -93,7 +90,7 @@ class _ResetLink extends State<ResetLink> {
 
   Widget buildForm() {
     return Container(
-      width: screenWidth * 0.60,
+      width: ScreenSize.screenWidth * 0.60,
       child: FormBuilder(
         key: _emailAddressFormKey,
         child: buildEmailAddressField()

--- a/lib/authentication/password/reset_link.dart
+++ b/lib/authentication/password/reset_link.dart
@@ -55,15 +55,15 @@ class _ResetLink extends State<ResetLink> {
       alignment: Alignment.center,
       children: <Widget>[
         Positioned(
-          top: ScreenSize.screenHeight * 0.15,
+          top: ScreenSize.height * 0.15,
           child: buildCenterAno()
         ),
         Positioned(
-          top: ScreenSize.screenHeight * 0.35,
+          top: ScreenSize.height * 0.35,
           child: buildForm()
         ), 
         Positioned(
-          top: ScreenSize.screenHeight * 0.50,
+          top: ScreenSize.height * 0.50,
           child: buildResetLinkButton()
         )
       ]
@@ -72,12 +72,12 @@ class _ResetLink extends State<ResetLink> {
 
  Widget buildCenterAno() {
     return Container(
-      width: ScreenSize.screenWidth,
+      width: ScreenSize.width,
       child: Column(
         children: <Widget>[
           Image.asset(
             'images/sign_up/ano_hands_straight_up.png', 
-            height: ScreenSize.screenHeight * 0.11
+            height: ScreenSize.height * 0.11
           ),
           Container(
             height: 1.5,
@@ -90,7 +90,7 @@ class _ResetLink extends State<ResetLink> {
 
   Widget buildForm() {
     return Container(
-      width: ScreenSize.screenWidth * 0.60,
+      width: ScreenSize.width * 0.60,
       child: FormBuilder(
         key: _emailAddressFormKey,
         child: buildEmailAddressField()

--- a/lib/authentication/sign_up/funnel.dart
+++ b/lib/authentication/sign_up/funnel.dart
@@ -49,7 +49,7 @@ class SignUpFunnel extends StatelessWidget {
       children: [
         Image.asset(
           'images/sign_up/ano_hands_up.png', 
-          height: ScreenSize.screenHeight * 0.11
+          height: ScreenSize.height * 0.11
         ),
         Container(height: 1.5, color: Colors.white)
       ]
@@ -58,8 +58,8 @@ class SignUpFunnel extends StatelessWidget {
 
   // TODO: Make a common global_footer widget to maintain consistent padding
   Widget buildFooter(context) {
-    var verticalPadding = ScreenSize.screenHeight * 0.08;
-    var horizontalPadding = ScreenSize.screenWidth * 0.21;
+    var verticalPadding = ScreenSize.height * 0.08;
+    var horizontalPadding = ScreenSize.width * 0.21;
 
     return Padding(
       padding: EdgeInsets.symmetric(
@@ -93,14 +93,14 @@ class SignUpFunnel extends StatelessWidget {
   
   // TODO: Make a common circle_indicators widget is created
   Row buildCircleIndicators() {
-    var circleDimensions = ScreenSize.screenWidth * 0.01;
+    var circleDimensions = ScreenSize.width * 0.01;
     var circles = <Widget>[];
     for (var i = 0; i < 3; i++) {
       circles.add(
         Container(
           width: circleDimensions, 
           height: circleDimensions, 
-          margin: EdgeInsets.all(ScreenSize.screenWidth * 0.02), 
+          margin: EdgeInsets.all(ScreenSize.width * 0.02), 
           decoration: BoxDecoration(
             color: i == 0 ? 
               ThemeColors.accent : Colors.grey, 

--- a/lib/authentication/sign_up/funnel.dart
+++ b/lib/authentication/sign_up/funnel.dart
@@ -11,6 +11,8 @@ class SignUpFunnel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    CommonContext().init(context);
+
     return Scaffold(
       // TODO: Replace with primaryColor when center ano image is updated
       backgroundColor: Color(0xFF0B0B33),
@@ -42,13 +44,12 @@ class SignUpFunnel extends StatelessWidget {
   }
 
   Widget buildCenterAno(context) {
-    var screenHeight = MediaQuery.of(context).size.height;
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         Image.asset(
           'images/sign_up/ano_hands_up.png', 
-          height: screenHeight * 0.11
+          height: ScreenSize.screenHeight * 0.11
         ),
         Container(height: 1.5, color: Colors.white)
       ]
@@ -57,24 +58,20 @@ class SignUpFunnel extends StatelessWidget {
 
   // TODO: Make a common global_footer widget to maintain consistent padding
   Widget buildFooter(context) {
-    var screenWidth = MediaQuery.of(context).size.width; 
-    var screenHeight = MediaQuery.of(context).size.height; 
-    var heightPadding = screenHeight * 0.08;
-    var widthPadding = screenWidth * 0.21;
+    var verticalPadding = ScreenSize.screenHeight * 0.08;
+    var horizontalPadding = ScreenSize.screenWidth * 0.21;
 
     return Padding(
-      padding: EdgeInsets.fromLTRB(
-        widthPadding, 
-        heightPadding, 
-        widthPadding, 
-        heightPadding
+      padding: EdgeInsets.symmetric(
+        horizontal: horizontalPadding, 
+        vertical: verticalPadding
       ), 
       child: Column(
         mainAxisAlignment: MainAxisAlignment.end,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           buildFunnelText(), 
-          buildCircleIndicators(context, screenWidth), 
+          buildCircleIndicators(), 
           ...buildFunnelButtons(context)
         ]
       )
@@ -95,18 +92,18 @@ class SignUpFunnel extends StatelessWidget {
   }
   
   // TODO: Make a common circle_indicators widget is created
-  Row buildCircleIndicators(context, screenWidth) {
-    var circleDimensions = screenWidth * 0.01;
+  Row buildCircleIndicators() {
+    var circleDimensions = ScreenSize.screenWidth * 0.01;
     var circles = <Widget>[];
     for (var i = 0; i < 3; i++) {
       circles.add(
         Container(
           width: circleDimensions, 
           height: circleDimensions, 
-          margin: EdgeInsets.all(screenWidth * 0.02), 
+          margin: EdgeInsets.all(ScreenSize.screenWidth * 0.02), 
           decoration: BoxDecoration(
             color: i == 0 ? 
-              Theme.of(context).accentColor : Colors.grey, 
+              ThemeColors.accentColor : Colors.grey, 
             shape: BoxShape.circle
           )
         )

--- a/lib/authentication/sign_up/funnel.dart
+++ b/lib/authentication/sign_up/funnel.dart
@@ -14,7 +14,7 @@ class SignUpFunnel extends StatelessWidget {
     CommonContext().init(context);
 
     return Scaffold(
-      // TODO: Replace with primaryColor when center ano image is updated
+      // TODO: Replace with primary when center ano image is updated
       backgroundColor: Color(0xFF0B0B33),
       body: Container(
         child: Stack(
@@ -103,7 +103,7 @@ class SignUpFunnel extends StatelessWidget {
           margin: EdgeInsets.all(ScreenSize.screenWidth * 0.02), 
           decoration: BoxDecoration(
             color: i == 0 ? 
-              ThemeColors.accentColor : Colors.grey, 
+              ThemeColors.accent : Colors.grey, 
             shape: BoxShape.circle
           )
         )

--- a/lib/authentication/sign_up/mentee_sign_up.dart
+++ b/lib/authentication/sign_up/mentee_sign_up.dart
@@ -218,7 +218,7 @@ class _MenteeSignUp extends State<MenteeSignUp> {
       child: FormBuilderTextField(
         attribute: 'fullName',
         focusNode: fullNameFocus,
-        style: fieldTextStyle(color: Theme.of(context).primaryColor),
+        style: fieldTextStyle(color: ThemeColors.primary),
         decoration: fieldDecoration(
           context,
           isFocused: isFullNameFocused,
@@ -242,7 +242,7 @@ class _MenteeSignUp extends State<MenteeSignUp> {
       child: FormBuilderTextField(
         attribute: 'emailAddress',
         focusNode: emailAddressFocus,
-        style: fieldTextStyle(color: Theme.of(context).primaryColor),
+        style: fieldTextStyle(color: ThemeColors.primary),
         decoration: fieldDecoration(
           context,
           isFocused: isEmailAddressFocused,
@@ -269,7 +269,7 @@ class _MenteeSignUp extends State<MenteeSignUp> {
         focusNode: passwordFocus,
         obscureText: true,
         maxLines: 1,
-        style: fieldTextStyle(color: Theme.of(context).primaryColor),
+        style: fieldTextStyle(color: ThemeColors.primary),
         decoration: fieldDecoration(
           context,
           isFocused: isPasswordFocused,

--- a/lib/authentication/sign_up/mentee_sign_up.dart
+++ b/lib/authentication/sign_up/mentee_sign_up.dart
@@ -166,11 +166,11 @@ class _MenteeSignUp extends State<MenteeSignUp> {
       alignment: Alignment.center,
       children: <Widget>[
         Positioned(
-          top: ScreenSize.screenHeight * 0.15,
+          top: ScreenSize.height * 0.15,
           child: buildCenterAno()
         ),
         Positioned(
-          top: ScreenSize.screenHeight * 0.35,
+          top: ScreenSize.height * 0.35,
           child: buildForm()
         ),
         buildFooter()
@@ -180,7 +180,7 @@ class _MenteeSignUp extends State<MenteeSignUp> {
 
   Widget buildForm() {
     return Container(
-      width: ScreenSize.screenWidth * 0.60,
+      width: ScreenSize.width * 0.60,
       child: FormBuilder(
         key: _signUpFormKey,
         child: Column(
@@ -196,12 +196,12 @@ class _MenteeSignUp extends State<MenteeSignUp> {
 
   Widget buildCenterAno() {
     return Container(
-      width: ScreenSize.screenWidth,
+      width: ScreenSize.width,
       child: Column(
         children: <Widget>[
           SvgPicture.asset(
             'images/diverse_ano.svg',
-            height: ScreenSize.screenHeight * 0.11,
+            height: ScreenSize.height * 0.11,
           ),
           Container(
             height: 1.5,
@@ -290,7 +290,7 @@ class _MenteeSignUp extends State<MenteeSignUp> {
 
   Widget buildFooter() {
     return Positioned(
-      bottom: ScreenSize.screenHeight * 0.05,
+      bottom: ScreenSize.height * 0.05,
       child: Column(
         children: <Widget>[
           CircleIndicators(stepIndex: 1),

--- a/lib/authentication/sign_up/mentee_sign_up.dart
+++ b/lib/authentication/sign_up/mentee_sign_up.dart
@@ -34,7 +34,6 @@ class _MenteeSignUp extends State<MenteeSignUp> {
   bool isFullNameInvalid, isEmailAddressInvalid, isPasswordInvalid;
   bool isLoading;
   Store<AppState> store;
-  double screenHeight, screenWidth;
 
   @override
   void initState() {
@@ -65,9 +64,7 @@ class _MenteeSignUp extends State<MenteeSignUp> {
 
   @override
   Widget build(BuildContext context) {
-
-    screenWidth = MediaQuery.of(context).size.width;
-    screenHeight = MediaQuery.of(context).size.height;
+    CommonContext().init(context);
 
     return Scaffold(
       backgroundColor: Colors.white,
@@ -169,11 +166,11 @@ class _MenteeSignUp extends State<MenteeSignUp> {
       alignment: Alignment.center,
       children: <Widget>[
         Positioned(
-          top: screenHeight * 0.15,
+          top: ScreenSize.screenHeight * 0.15,
           child: buildCenterAno()
         ),
         Positioned(
-          top: screenHeight * 0.35,
+          top: ScreenSize.screenHeight * 0.35,
           child: buildForm()
         ),
         buildFooter()
@@ -183,7 +180,7 @@ class _MenteeSignUp extends State<MenteeSignUp> {
 
   Widget buildForm() {
     return Container(
-      width: screenWidth * 0.60,
+      width: ScreenSize.screenWidth * 0.60,
       child: FormBuilder(
         key: _signUpFormKey,
         child: Column(
@@ -199,12 +196,12 @@ class _MenteeSignUp extends State<MenteeSignUp> {
 
   Widget buildCenterAno() {
     return Container(
-      width: screenWidth,
+      width: ScreenSize.screenWidth,
       child: Column(
         children: <Widget>[
           SvgPicture.asset(
             'images/diverse_ano.svg',
-            height: screenHeight * 0.11,
+            height: ScreenSize.screenHeight * 0.11,
           ),
           Container(
             height: 1.5,
@@ -293,7 +290,7 @@ class _MenteeSignUp extends State<MenteeSignUp> {
 
   Widget buildFooter() {
     return Positioned(
-      bottom: screenHeight * 0.05,
+      bottom: ScreenSize.screenHeight * 0.05,
       child: Column(
         children: <Widget>[
           CircleIndicators(stepIndex: 1),

--- a/lib/chat/chat.dart
+++ b/lib/chat/chat.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:redux/redux.dart';
 
-import '../common/global_header.dart';
+import '../common/common.dart';
 import '../constants/constants.dart';
 import '../models/models.dart';
 import '../selectors/selectors.dart';

--- a/lib/chat/chat.dart
+++ b/lib/chat/chat.dart
@@ -55,7 +55,7 @@ class _ChatState extends State<Chat> {
           );
           return Scaffold(
             body: Container(
-              height: MediaQuery.of(context).size.height,
+              height: ScreenSize.height,
               margin: EdgeInsets.all(0),
               child: Center(
                 child: Column(

--- a/lib/chat/chat_messenger.dart
+++ b/lib/chat/chat_messenger.dart
@@ -340,7 +340,7 @@ class ChatMessengerState extends State<ChatMessenger> {
           ),
           backgroundColor: Colors.white,
           body: Container(
-            height: MediaQuery.of(context).size.height,
+            height: ScreenSize.height,
             margin: EdgeInsets.all(0),
             child: Center(
               child: Column(

--- a/lib/chat/chat_messenger.dart
+++ b/lib/chat/chat_messenger.dart
@@ -159,7 +159,7 @@ class ChatMessengerState extends State<ChatMessenger> {
       icon: icon,
       iconSize: 24.0,
       padding: EdgeInsets.all(0.0),
-      color: Theme.of(context).accentColor,
+      color: ThemeColors.accent,
       onPressed: onPressed,
     );
   }
@@ -331,7 +331,7 @@ class ChatMessengerState extends State<ChatMessenger> {
               },
               icon: Icon(
                 Icons.arrow_back_ios,
-                color: Theme.of(context).accentColor
+                color: ThemeColors.accent
               )
             ),
             backgroundColor: Colors.white,

--- a/lib/chat/common/message_row.dart
+++ b/lib/chat/common/message_row.dart
@@ -54,7 +54,7 @@ class MessageRow extends StatelessWidget {
             style: TextStyle(
               color: isRead == true || isSent == true ? 
                 Colors.grey : 
-                Theme.of(context).accentColor,
+                ThemeColors.accent,
             ),
             text: lastMessageType == 0 ? 
               lastMessage.content : 
@@ -116,7 +116,7 @@ class MessageRow extends StatelessWidget {
           border: Border.all(
             color: isRead || isSent ? 
               Colors.grey : 
-              Theme.of(context).accentColor, 
+              ThemeColors.accent, 
             width: 1.0
           ),
           borderRadius: BorderRadius.all(Radius.circular(15.0)),

--- a/lib/chat/message.dart
+++ b/lib/chat/message.dart
@@ -18,7 +18,7 @@ class MessageView extends StatelessWidget {
     var margin = isSent ? 
       BubbleEdges.fromLTRB(50.0, 10.0, 10.0, 10.0) :
       BubbleEdges.fromLTRB(10.0, 10.0, 50.0, 10.0);
-    var color = isSent ? Theme.of(context).accentColor : Colors.grey;
+    var color = isSent ? ThemeColors.accent : Colors.grey;
     return Bubble(
       nip: nip,
       nipOffset: 0.0,
@@ -40,7 +40,7 @@ class MessageView extends StatelessWidget {
     var margin = isSent ? 
       BubbleEdges.fromLTRB(50.0, 10.0, 10.0, 10.0) :
       BubbleEdges.fromLTRB(10.0, 10.0, 50.0, 10.0);
-    var color = isSent ? Theme.of(context).accentColor : Colors.grey;
+    var color = isSent ? ThemeColors.accent : Colors.grey;
     return Bubble(
       nip: nip,
       nipOffset: 0.0,

--- a/lib/chat/new_matches.dart
+++ b/lib/chat/new_matches.dart
@@ -92,7 +92,7 @@ buildNewMatches(context, newMatchesList, id, isMentee) {
   }
 
   return Container(
-    width: MediaQuery.of(context).size.width,
+    width: ScreenSize.width,
     child: Row(
       children: <Widget>[
         Container(

--- a/lib/chat/new_matches.dart
+++ b/lib/chat/new_matches.dart
@@ -2,7 +2,7 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter/material.dart';
 import 'package:redux/redux.dart';
 
-import '../common/format_text.dart';
+import '../common/common.dart';
 import '../models/models.dart';
 import '../selectors/selectors.dart';
 import './chat_messenger.dart';

--- a/lib/common/circle_indicators.dart
+++ b/lib/common/circle_indicators.dart
@@ -18,7 +18,7 @@ class CircleIndicators extends StatelessWidget {
   }
 
   List<Widget> buildCircles(BuildContext context) {
-    var screenWidth = MediaQuery.of(context).size.width;
+    var screenWidth = ScreenSize.width;
     var circleDimensions = screenWidth * 0.01;
     var circles = <Widget>[];
     

--- a/lib/common/circle_indicators.dart
+++ b/lib/common/circle_indicators.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import './common_context.dart';
+
 class CircleIndicators extends StatelessWidget {
   final int stepIndex;
   
@@ -7,6 +9,8 @@ class CircleIndicators extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    CommonContext().init(context);
+
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: buildCircles(context)
@@ -26,7 +30,7 @@ class CircleIndicators extends StatelessWidget {
           margin: EdgeInsets.all(screenWidth * 0.02), 
           decoration: BoxDecoration(
             color: i == stepIndex ? 
-              Theme.of(context).accentColor : Colors.grey, 
+              ThemeColors.accent : Colors.grey, 
             shape: BoxShape.circle
           )
         )

--- a/lib/common/common.dart
+++ b/lib/common/common.dart
@@ -1,4 +1,5 @@
 export 'circle_indicators.dart';
+export 'common_context.dart';
 export 'footer_links.dart';
 export 'format_text.dart';
 export 'global_header.dart';

--- a/lib/common/common_context.dart
+++ b/lib/common/common_context.dart
@@ -8,8 +8,8 @@ class CommonContext {
 }
 class ScreenSize {
   static MediaQueryData _mediaQueryData;
-  static double screenWidth;
-  static double screenHeight;
+  static double width;
+  static double height;
   static double blockSizeHorizontal;
   static double blockSizeVertical;
   
@@ -20,18 +20,18 @@ class ScreenSize {
   
   void init(BuildContext context) {
     _mediaQueryData = MediaQuery.of(context);
-    screenWidth = _mediaQueryData.size.width;
-    screenHeight = _mediaQueryData.size.height;
-    blockSizeHorizontal = screenWidth / 100;
-    blockSizeVertical = screenHeight / 100;
+    width = _mediaQueryData.size.width;
+    height = _mediaQueryData.size.height;
+    blockSizeHorizontal = width / 100;
+    blockSizeVertical = height / 100;
     
     _safeAreaHorizontal = _mediaQueryData.padding.left + 
     _mediaQueryData.padding.right;
     _safeAreaVertical = _mediaQueryData.padding.top +
     _mediaQueryData.padding.bottom;
-    safeBlockHorizontal = (screenWidth -
+    safeBlockHorizontal = (width -
     _safeAreaHorizontal) / 100;
-    safeBlockVertical = (screenHeight -
+    safeBlockVertical = (height -
     _safeAreaVertical) / 100;
   }
 }

--- a/lib/common/common_context.dart
+++ b/lib/common/common_context.dart
@@ -37,11 +37,11 @@ class ScreenSize {
 }
 
 class ThemeColors {
-  static var primaryColor;
-  static var accentColor;
+  static var primary;
+  static var accent;
 
   void init(BuildContext context) {
-    primaryColor = Color(0xFF0F1236);
-    accentColor = Color(0xFF45cab9); 
+    primary = Color(0xFF0F1236);
+    accent = Color(0xFF45cab9); 
   }
 }

--- a/lib/common/common_context.dart
+++ b/lib/common/common_context.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+class CommonContext {
+  void init(BuildContext context) {
+    ScreenSize().init(context);
+    ThemeColors().init(context);
+  }
+}
+class ScreenSize {
+  static MediaQueryData _mediaQueryData;
+  static double screenWidth;
+  static double screenHeight;
+  static double blockSizeHorizontal;
+  static double blockSizeVertical;
+  
+  static double _safeAreaHorizontal;
+  static double _safeAreaVertical;
+  static double safeBlockHorizontal;
+  static double safeBlockVertical;
+  
+  void init(BuildContext context) {
+    _mediaQueryData = MediaQuery.of(context);
+    screenWidth = _mediaQueryData.size.width;
+    screenHeight = _mediaQueryData.size.height;
+    blockSizeHorizontal = screenWidth / 100;
+    blockSizeVertical = screenHeight / 100;
+    
+    _safeAreaHorizontal = _mediaQueryData.padding.left + 
+    _mediaQueryData.padding.right;
+    _safeAreaVertical = _mediaQueryData.padding.top +
+    _mediaQueryData.padding.bottom;
+    safeBlockHorizontal = (screenWidth -
+    _safeAreaHorizontal) / 100;
+    safeBlockVertical = (screenHeight -
+    _safeAreaVertical) / 100;
+  }
+}
+
+class ThemeColors {
+  static var primaryColor;
+  static var accentColor;
+
+  void init(BuildContext context) {
+    primaryColor = Color(0xFF0F1236);
+    accentColor = Color(0xFF45cab9); 
+  }
+}

--- a/lib/common/global_header.dart
+++ b/lib/common/global_header.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../constants/common_constants.dart';
-import 'format_text.dart';
+import './common.dart';
 
 class GlobalHeader extends StatelessWidget implements PreferredSizeWidget {
   final String actionText;
@@ -19,6 +19,7 @@ class GlobalHeader extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     var showAction = actionText != null && onActionTap != null;
+    CommonContext().init(context);
 
     return AppBar(
       title: appBarTitle(), 
@@ -53,7 +54,7 @@ class GlobalHeader extends StatelessWidget implements PreferredSizeWidget {
             text: actionText,
             textColor: isLight 
               ? Colors.grey[50] 
-              : Theme.of(context).accentColor,
+              : ThemeColors.accent,
             fontSize: 14.0,
             fontWeight: FontWeight.w500
           )

--- a/lib/common/info_border.dart
+++ b/lib/common/info_border.dart
@@ -17,7 +17,7 @@ class InfoBorder extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: width ?? MediaQuery.of(context).size.width * 0.50,
+      width: width ?? ScreenSize.width * 0.50,
       padding: EdgeInsets.only(top: 10.0, bottom: 10),
       alignment: Alignment.center,
       decoration: ShapeDecoration(

--- a/lib/common/info_border.dart
+++ b/lib/common/info_border.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import 'format_text.dart';
+import './common.dart';
 
 class InfoBorder extends StatelessWidget {
   final String text;
@@ -23,13 +23,13 @@ class InfoBorder extends StatelessWidget {
       decoration: ShapeDecoration(
         color: Colors.white,
         shape: RoundedRectangleBorder(
-          side: BorderSide(color: Theme.of(context).accentColor),
+          side: BorderSide(color: ThemeColors.accent),
           borderRadius: BorderRadius.all(Radius.circular(20.0))
         )
       ),
       child: FormatText(
         text: text,
-        textColor: Theme.of(context).accentColor,
+        textColor: ThemeColors.accent,
         textAlign: TextAlign.center,
         fontSize: 14.0,
         fontWeight: FontWeight.w500,

--- a/lib/common/primary_button.dart
+++ b/lib/common/primary_button.dart
@@ -24,7 +24,7 @@ class PrimaryButton extends StatelessWidget {
     CommonContext().init(context);
 
     return MaterialButton(
-      minWidth: minWidth ?? MediaQuery.of(context).size.width * 0.50,
+      minWidth: minWidth ?? ScreenSize.width * 0.50,
       height: height,
       onPressed: onPressed,
       color: isLight 

--- a/lib/common/primary_button.dart
+++ b/lib/common/primary_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import './common_context.dart';
 import './format_text.dart';
 
 class PrimaryButton extends StatelessWidget {
@@ -20,13 +21,15 @@ class PrimaryButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    CommonContext().init(context);
+
     return MaterialButton(
       minWidth: minWidth ?? MediaQuery.of(context).size.width * 0.50,
       height: height,
       onPressed: onPressed,
       color: isLight 
-        ? Theme.of(context).accentColor
-        : Theme.of(context).primaryColor,
+        ? ThemeColors.accent
+        : ThemeColors.primary,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.all(Radius.circular(20.0))
       ),

--- a/lib/common/styles.dart
+++ b/lib/common/styles.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+import './common_context.dart';
+
 InputDecoration fieldDecoration(
   BuildContext context, {
     String hintText,
@@ -21,7 +23,7 @@ InputDecoration fieldDecoration(
     ),
     focusedBorder: OutlineInputBorder(
       borderSide: BorderSide(
-        color: Theme.of(context).accentColor,
+        color: ThemeColors.accent,
         width: 1.0
       ),
       borderRadius: BorderRadius.all(Radius.zero),
@@ -39,7 +41,7 @@ InputDecoration fieldDecoration(
     prefixIcon: Icon(
       icon,
       color: isFocused && !isInvalid 
-      ? Theme.of(context).accentColor
+      ? ThemeColors.accent
       : Colors.grey,
       size: 20.0
     )

--- a/lib/constants/constants.dart
+++ b/lib/constants/constants.dart
@@ -5,4 +5,3 @@ export 'common_constants.dart';
 export 'ftu_constants.dart';
 export 'pairings_constants.dart';
 export 'profile_constants.dart';
-export 'theme_constants.dart';

--- a/lib/constants/theme_constants.dart
+++ b/lib/constants/theme_constants.dart
@@ -1,4 +1,0 @@
-import 'package:flutter/material.dart';
-
-const primaryColor = Color(0xFF0F1236);	
-const accentColor = Color(0xFF45cab9);

--- a/lib/ftu/onboarding/intro.dart
+++ b/lib/ftu/onboarding/intro.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
 import '../../common/common.dart';
-import '../../common/common_context.dart';
 import '../../constants/constants.dart';
 import './steps.dart';
 

--- a/lib/ftu/onboarding/intro.dart
+++ b/lib/ftu/onboarding/intro.dart
@@ -16,12 +16,12 @@ class OnboardingIntro extends StatelessWidget {
     return Scaffold(
       backgroundColor: ThemeColors.primary,
       body: Container(
-        width: ScreenSize.screenWidth,
+        width: ScreenSize.width,
         child: Stack(
           alignment: Alignment.center,
           children: <Widget>[
             Positioned(
-              top: ScreenSize.screenHeight * 0.15,
+              top: ScreenSize.height * 0.15,
               child: buildTitle()
             ),
             Column(
@@ -31,7 +31,7 @@ class OnboardingIntro extends StatelessWidget {
               ]
             ),
             Positioned(
-              bottom: ScreenSize.screenHeight * 0.10,
+              bottom: ScreenSize.height * 0.10,
               child: buildGetStartedButton(context)
             )
           ]
@@ -69,21 +69,21 @@ class OnboardingIntro extends StatelessWidget {
   Widget buildCenterLogo() {
     return Container(
       padding: EdgeInsets.only(
-        top: ScreenSize.screenHeight * 0.40
+        top: ScreenSize.height * 0.40
       ),
       child: SvgPicture.asset(
         'images/light_logo.svg',
-        height: ScreenSize.screenHeight * 0.15,
-        width: ScreenSize.screenHeight * 0.15,
+        height: ScreenSize.height * 0.15,
+        width: ScreenSize.height * 0.15,
       )
     );
   }
 
   Widget buildBottomText() {
     return Container(
-      width: ScreenSize.screenWidth * 0.60,
+      width: ScreenSize.width * 0.60,
       padding: EdgeInsets.only(
-        top: ScreenSize.screenHeight * 0.20
+        top: ScreenSize.height * 0.20
       ),
       child: FormatText(
         text: getStartedBottomText,

--- a/lib/ftu/onboarding/intro.dart
+++ b/lib/ftu/onboarding/intro.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
 import '../../common/common.dart';
+import '../../common/common_context.dart';
 import '../../constants/constants.dart';
 import './steps.dart';
 
@@ -11,28 +12,27 @@ class OnboardingIntro extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var screenWidth = MediaQuery.of(context).size.width;
-    var screenHeight = MediaQuery.of(context).size.height;
-
+    CommonContext().init(context);
+  
     return Scaffold(
-      backgroundColor: Theme.of(context).primaryColor,
+      backgroundColor: ThemeColors.primaryColor,
       body: Container(
-        width: screenWidth,
+        width: ScreenSize.screenWidth,
         child: Stack(
           alignment: Alignment.center,
           children: <Widget>[
             Positioned(
-              top: screenHeight * 0.15,
+              top: ScreenSize.screenHeight * 0.15,
               child: buildTitle()
             ),
             Column(
               children: <Widget>[
-                buildCenterLogo(screenHeight),
-                buildBottomText(screenHeight, screenWidth)
+                buildCenterLogo(),
+                buildBottomText()
               ]
             ),
             Positioned(
-              bottom: screenHeight * 0.10,
+              bottom: ScreenSize.screenHeight * 0.10,
               child: buildGetStartedButton(context)
             )
           ]
@@ -67,24 +67,24 @@ class OnboardingIntro extends StatelessWidget {
     );
   }
 
-  Widget buildCenterLogo(double screenHeight) {
+  Widget buildCenterLogo() {
     return Container(
       padding: EdgeInsets.only(
-        top: screenHeight * 0.40
+        top: ScreenSize.screenHeight * 0.40
       ),
       child: SvgPicture.asset(
         'images/light_logo.svg',
-        height: screenHeight * 0.15,
-        width: screenHeight * 0.15,
+        height: ScreenSize.screenHeight * 0.15,
+        width: ScreenSize.screenHeight * 0.15,
       )
     );
   }
 
-  Widget buildBottomText(double screenHeight, double screenWidth) {
+  Widget buildBottomText() {
     return Container(
-      width: screenWidth * 0.60,
+      width: ScreenSize.screenWidth * 0.60,
       padding: EdgeInsets.only(
-        top: screenHeight * 0.20
+        top: ScreenSize.screenHeight * 0.20
       ),
       child: FormatText(
         text: getStartedBottomText,

--- a/lib/ftu/onboarding/intro.dart
+++ b/lib/ftu/onboarding/intro.dart
@@ -14,7 +14,7 @@ class OnboardingIntro extends StatelessWidget {
     CommonContext().init(context);
   
     return Scaffold(
-      backgroundColor: ThemeColors.primaryColor,
+      backgroundColor: ThemeColors.primary,
       body: Container(
         width: ScreenSize.screenWidth,
         child: Stack(

--- a/lib/ftu/onboarding/steps.dart
+++ b/lib/ftu/onboarding/steps.dart
@@ -2,11 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_animator/flutter_animator.dart';
 
 import '../../authentication/login_signup_funnel.dart';
-import '../../common/circle_indicators.dart';
-import '../../common/common_context.dart';
-import '../../common/format_text.dart';
-import '../../common/global_header.dart';
-import '../../common/primary_button.dart';
+import '../../common/common.dart';
 import '../../constants/common_constants.dart';
 import '../../constants/ftu_constants.dart';
 

--- a/lib/ftu/onboarding/steps.dart
+++ b/lib/ftu/onboarding/steps.dart
@@ -3,6 +3,7 @@ import 'package:flutter_animator/flutter_animator.dart';
 
 import '../../authentication/login_signup_funnel.dart';
 import '../../common/circle_indicators.dart';
+import '../../common/common_context.dart';
 import '../../common/format_text.dart';
 import '../../common/global_header.dart';
 import '../../common/primary_button.dart';
@@ -20,7 +21,6 @@ class OnboardingSteps extends StatefulWidget {
 class _OnboardingSteps extends State<OnboardingSteps> {
 
   int stepIndex;
-  double screenWidth, screenHeight;
 
   @override
   void initState() {
@@ -31,9 +31,8 @@ class _OnboardingSteps extends State<OnboardingSteps> {
 
   @override
   Widget build(BuildContext context) {
-    screenWidth = MediaQuery.of(context).size.width;
-    screenHeight = MediaQuery.of(context).size.height;
-
+    CommonContext().init(context);
+    
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: buildHeader(),
@@ -78,12 +77,12 @@ class _OnboardingSteps extends State<OnboardingSteps> {
 
   Widget buildCenterAno() {
     return Padding(
-      padding: EdgeInsets.only(top: screenHeight * 0.30),
+      padding: EdgeInsets.only(top: ScreenSize.screenHeight * 0.30),
       child: SlideInRight(
         key: onboardingStepsConfig[stepIndex]["imageKey"],
         child: Image.asset(
           onboardingStepsConfig[stepIndex]["image"],
-          height: screenHeight * 0.15
+          height: ScreenSize.screenHeight * 0.15
         ),
       )
     );
@@ -93,8 +92,8 @@ class _OnboardingSteps extends State<OnboardingSteps> {
     return SlideInRight(
       key: onboardingStepsConfig[stepIndex]["textKey"],
       child: Container(
-        padding: EdgeInsets.only(top: screenHeight * 0.15),
-        width: screenWidth * 0.60,
+        padding: EdgeInsets.only(top: ScreenSize.screenHeight * 0.15),
+        width: ScreenSize.screenWidth * 0.60,
         child: FormatText(
           text: onboardingStepsConfig[stepIndex]["text"],
           textColor: Colors.black,
@@ -108,7 +107,7 @@ class _OnboardingSteps extends State<OnboardingSteps> {
 
   Widget buildFooter() {
     return Positioned(
-      bottom: screenHeight * 0.10,
+      bottom: ScreenSize.screenHeight * 0.10,
       child: Column(
         children: <Widget>[
           CircleIndicators(stepIndex: stepIndex),

--- a/lib/ftu/onboarding/steps.dart
+++ b/lib/ftu/onboarding/steps.dart
@@ -73,12 +73,12 @@ class _OnboardingSteps extends State<OnboardingSteps> {
 
   Widget buildCenterAno() {
     return Padding(
-      padding: EdgeInsets.only(top: ScreenSize.screenHeight * 0.30),
+      padding: EdgeInsets.only(top: ScreenSize.height * 0.30),
       child: SlideInRight(
         key: onboardingStepsConfig[stepIndex]["imageKey"],
         child: Image.asset(
           onboardingStepsConfig[stepIndex]["image"],
-          height: ScreenSize.screenHeight * 0.15
+          height: ScreenSize.height * 0.15
         ),
       )
     );
@@ -88,8 +88,8 @@ class _OnboardingSteps extends State<OnboardingSteps> {
     return SlideInRight(
       key: onboardingStepsConfig[stepIndex]["textKey"],
       child: Container(
-        padding: EdgeInsets.only(top: ScreenSize.screenHeight * 0.15),
-        width: ScreenSize.screenWidth * 0.60,
+        padding: EdgeInsets.only(top: ScreenSize.height * 0.15),
+        width: ScreenSize.width * 0.60,
         child: FormatText(
           text: onboardingStepsConfig[stepIndex]["text"],
           textColor: Colors.black,
@@ -103,7 +103,7 @@ class _OnboardingSteps extends State<OnboardingSteps> {
 
   Widget buildFooter() {
     return Positioned(
-      bottom: ScreenSize.screenHeight * 0.10,
+      bottom: ScreenSize.height * 0.10,
       child: Column(
         children: <Widget>[
           CircleIndicators(stepIndex: stepIndex),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,7 +8,6 @@ import 'package:redux_persist_flutter/redux_persist_flutter.dart';
 
 import './constants/constants.dart';
 import './models/models.dart';
-import './navigation/app_controller.dart';
 import './navigation/root.dart';
 import './reducers/reducers.dart';
 
@@ -45,26 +44,19 @@ void main() async {
       child: DevicePreview(
         enabled: enableDevicePreview,
         areSettingsEnabled: true,  
-        builder: (context) => App()
+        builder: app
       )
     )
   );
 }
 
-class App extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData(	
-        primaryColor: primaryColor,	
-        accentColor: accentColor,	
-      ),
-      initialRoute: '/',
-      routes: {
-        '/': (context) => Root(),
-        '/AppController': (context) => AppController()
-      }
-    );
-  }
+MaterialApp app(context) {
+  return MaterialApp(
+    debugShowCheckedModeBanner: false,
+    theme: ThemeData(	
+      primaryColor: primaryColor,	
+      accentColor: accentColor,	
+    ),
+    home: Root()
+  );
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:redux_logging/redux_logging.dart';
 import 'package:redux_persist/redux_persist.dart';
 import 'package:redux_persist_flutter/redux_persist_flutter.dart';
 
-import './constants/constants.dart';
+import './common/common_context.dart';
 import './models/models.dart';
 import './navigation/root.dart';
 import './reducers/reducers.dart';
@@ -54,8 +54,8 @@ MaterialApp app(context) {
   return MaterialApp(
     debugShowCheckedModeBanner: false,
     theme: ThemeData(	
-      primaryColor: primaryColor,	
-      accentColor: accentColor,	
+      primaryColor: ThemeColors.primary,	
+      accentColor: ThemeColors.accent,	
     ),
     home: Root()
   );

--- a/lib/pairings/pairings.dart
+++ b/lib/pairings/pairings.dart
@@ -1,19 +1,14 @@
 import 'package:flutter/material.dart';
 
 import '../common/common.dart';
-import '../common/global_header.dart';
 import '../constants/constants.dart';
-
-double screenWidth;
-double screenHeight;
 
 class Pairings extends StatelessWidget {
   const Pairings({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    screenWidth ??= MediaQuery.of(context)?.size?.width;
-    screenHeight ??= MediaQuery.of(context)?.size?.height;
+    CommonContext().init(context);
 
     return Scaffold(
       appBar: GlobalHeader(),
@@ -31,7 +26,7 @@ class Pairings extends StatelessWidget {
   Image buildAno() {
     return Image.asset(
       'images/ano_mountains.png',
-      height: screenHeight * 0.25
+      height: ScreenSize.height * 0.25
     );
   }
 
@@ -49,15 +44,15 @@ class Pairings extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Container(
-          width: screenWidth * 0.10, 
-          height: screenHeight * 0.10,
+          width: ScreenSize.width * 0.10, 
+          height: ScreenSize.height * 0.10,
           decoration: BoxDecoration(
             color: Colors.grey[200], 
             shape: BoxShape.circle
           )
         ), 
         Padding(
-          padding: EdgeInsets.only(top: screenHeight * 0.03), 
+          padding: EdgeInsets.only(top: ScreenSize.height * 0.03), 
           child: FormatText(
             text: dummyCard["name"],
             fontSize: 22.0
@@ -84,13 +79,13 @@ class Pairings extends StatelessWidget {
           onTap: () => print("Arrow pressed"),
           child: Image.asset(
             'images/right_arrow.png', 
-            height: screenHeight * 0.015
+            height: ScreenSize.height * 0.015
           )
         ),
         IconButton(
           icon: Icon(Icons.favorite),
-          iconSize: screenHeight * 0.03, 
-          color: Theme.of(context).accentColor,
+          iconSize: ScreenSize.height * 0.03, 
+          color: ThemeColors.accent,
           onPressed: () => print("Heart pressed"),
         )
       ]
@@ -100,8 +95,8 @@ class Pairings extends StatelessWidget {
   Widget buildCurrentCard(context) {
     return Padding(
       padding: EdgeInsets.symmetric(
-        vertical: screenHeight * 0.02, 
-        horizontal: screenWidth * 0.05
+        vertical: ScreenSize.height * 0.02, 
+        horizontal: ScreenSize.width * 0.05
       ),
       child: Column(
         children: [
@@ -117,7 +112,7 @@ class Pairings extends StatelessWidget {
   BoxDecoration buildCardContainer(context) {
     return BoxDecoration(
       border: Border.all(
-        color: Theme.of(context).accentColor,
+        color: ThemeColors.accent,
         width: 1.0,
         style: BorderStyle.solid
       ),
@@ -131,8 +126,8 @@ class Pairings extends StatelessWidget {
     return Align(
       alignment: Alignment.center, 
       child: Container(
-        width: screenWidth * 0.80,
-        height: screenHeight * 0.42,
+        width: ScreenSize.width * 0.80,
+        height: ScreenSize.height * 0.42,
         decoration: buildCardContainer(context), 
         child: Stack(
           overflow: Overflow.visible, 
@@ -140,7 +135,7 @@ class Pairings extends StatelessWidget {
           children: [
             buildCurrentCard(context), 
             Positioned(
-              top: screenHeight * 0.39, 
+              top: ScreenSize.height * 0.39, 
               child: buildReadMoreButton()
             )
           ]

--- a/lib/profile/common/app_bar.dart
+++ b/lib/profile/common/app_bar.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+import '../../common/common_context.dart';
 import '../../constants/profile_constants.dart';
 
 class AppBarWithSave extends StatelessWidget implements PreferredSizeWidget {
@@ -32,7 +33,7 @@ class AppBarWithSave extends StatelessWidget implements PreferredSizeWidget {
     return AppBar(
       leading: closeActionEnabled ? closeAction(context) : null,
       actions: <Widget>[saveAction(formKey)],
-      backgroundColor: Theme.of(context).primaryColor,
+      backgroundColor: ThemeColors.primary,
       centerTitle: true,
       title: buildAppBarTitle()
     );

--- a/lib/profile/common/date_picker.dart
+++ b/lib/profile/common/date_picker.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_picker/flutter_picker.dart';
 
+import '../../common/common_context.dart';
 import '../common/styles.dart';
 
 class DatePicker {
@@ -20,6 +21,8 @@ class DatePicker {
   });
 
   Picker build(BuildContext context) {
+    CommonContext().init(context);
+
     return Picker(
       adapter: DateTimePickerAdapter(
         value: initialValue,
@@ -31,7 +34,7 @@ class DatePicker {
       textAlign: TextAlign.right,
       onConfirm: onConfirm,
       hideHeader: false,
-      height: MediaQuery.of(context).size.height * 0.30,
+      height: ScreenSize.height * 0.30,
       itemExtent: 30.0,
       magnification: 1.5,
       squeeze: 0.80,

--- a/lib/profile/common/list_picker.dart
+++ b/lib/profile/common/list_picker.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_picker/flutter_picker.dart';
 
+import '../../common/common_context.dart';
 import '../common/styles.dart';
 
 class ListPicker {
@@ -29,11 +30,13 @@ class ListPicker {
   }
 
   Picker build(BuildContext context) {
+    CommonContext().init(context);
+    
     return Picker(
       adapter: PickerDataAdapter(data: getData()),
       selecteds: selecteds,
       hideHeader: false,
-      height: MediaQuery.of(context).size.height * 0.15,
+      height: ScreenSize.height * 0.15,
       itemExtent: 30.0,
       magnification: 1.5,
       squeeze: 0.80,

--- a/lib/profile/common/section.dart
+++ b/lib/profile/common/section.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+
+import '../../common/common.dart';
  
 class Section extends StatelessWidget {  
   final String title;
@@ -9,6 +11,7 @@ class Section extends StatelessWidget {
   
   @override
   Widget build(BuildContext context) {
+    CommonContext().init(context);
 
     final sectionTheme = Theme.of(context).copyWith(
       dividerColor: Colors.transparent,
@@ -17,7 +20,7 @@ class Section extends StatelessWidget {
     );
 
     return Container(
-      width: MediaQuery.of(context).size.width,
+      width: ScreenSize.width,
       padding: EdgeInsets.fromLTRB(30.0, 0, 30.0 ,0),
       decoration: BoxDecoration(
         border: Border(
@@ -69,7 +72,7 @@ class SectionRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: MediaQuery.of(context).size.width,
+      width: ScreenSize.width,
       padding: EdgeInsets.only(bottom: 10.0),
       margin: EdgeInsets.only(bottom: 10.0),
       decoration: BoxDecoration(

--- a/lib/profile/save_profile/sections/experience/experience_item.dart
+++ b/lib/profile/save_profile/sections/experience/experience_item.dart
@@ -8,6 +8,7 @@ import 'package:random_string/random_string.dart';
 import 'package:redux/redux.dart';
 
 import '../../../../actions/actions.dart';
+import '../../../../common/common_context.dart';
 import '../../../../constants/profile_constants.dart';
 import '../../../../models/models.dart';
 import '../../../../selectors/selectors.dart';
@@ -374,7 +375,7 @@ class _SaveExperienceItemState extends State<SaveExperienceItem> {
         style: labelTextStyle(isEnabled: job.startDate != null),
       ),
       contentPadding: EdgeInsets.all(0.0),
-      activeColor: Theme.of(context).primaryColor,
+      activeColor: ThemeColors.primary,
       decoration: InputDecoration(
         isDense: true,
         contentPadding: EdgeInsets.all(0.0),

--- a/lib/profile/view_profile/header.dart
+++ b/lib/profile/view_profile/header.dart
@@ -23,7 +23,7 @@ class ProfileHeader extends StatelessWidget {
     CommonContext().init(context);
 
     return Container(
-      width: MediaQuery.of(context).size.width, 
+      width: ScreenSize.width, 
       height: profileHeaderHeight,
       decoration: BoxDecoration(
         color: ThemeColors.primary, 
@@ -36,7 +36,7 @@ class ProfileHeader extends StatelessWidget {
           Positioned(
             top: 40.0,
             left: 0,
-            width: MediaQuery.of(context).size.width,
+            width: ScreenSize.width,
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget> [

--- a/lib/profile/view_profile/header.dart
+++ b/lib/profile/view_profile/header.dart
@@ -3,6 +3,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+import '../../common/common_context.dart';
 import '../../constants/profile_constants.dart';
 import '../save_profile/save_profile.dart';
  
@@ -19,11 +20,13 @@ class ProfileHeader extends StatelessWidget {
   
   @override
   Widget build(BuildContext context) {
+    CommonContext().init(context);
+
     return Container(
       width: MediaQuery.of(context).size.width, 
       height: profileHeaderHeight,
       decoration: BoxDecoration(
-        color: Theme.of(context).primaryColor, 
+        color: ThemeColors.primary, 
         borderRadius: BorderRadius.only(
           bottomLeft: Radius.circular(40.0)
         ),
@@ -57,7 +60,7 @@ class ProfileHeader extends StatelessWidget {
       width: 60.0, 
       height: 60.0, 
       decoration: BoxDecoration(
-        color: Theme.of(context).accentColor, 
+        color: ThemeColors.accent, 
         shape: BoxShape.circle
       )
     );

--- a/test/chat/chat_test.dart
+++ b/test/chat/chat_test.dart
@@ -12,7 +12,7 @@ import 'package:aspire/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(App());
+    await tester.pumpWidget(app);
 
     // Verify navigations
   });

--- a/test/dashboard/dashboard_test.dart
+++ b/test/dashboard/dashboard_test.dart
@@ -12,7 +12,7 @@ import 'package:aspire/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(App());
+    await tester.pumpWidget(app);
 
     // Verify navigations
   });

--- a/test/ftu/filters_test.dart
+++ b/test/ftu/filters_test.dart
@@ -12,7 +12,7 @@ import 'package:aspire/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(App());
+    await tester.pumpWidget(app);
 
     // Verify navigations
   });

--- a/test/ftu/signup_test.dart
+++ b/test/ftu/signup_test.dart
@@ -12,7 +12,7 @@ import 'package:aspire/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(App());
+    await tester.pumpWidget(app);
 
     // Verify navigations
   });

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -12,7 +12,7 @@ import 'package:aspire/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(App());
+    await tester.pumpWidget(app);
 
     // Verify navigations
   });

--- a/test/navigation/app_controller_test.dart
+++ b/test/navigation/app_controller_test.dart
@@ -12,7 +12,7 @@ import 'package:aspire/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(App());
+    await tester.pumpWidget(app);
 
     // Verify navigations
   });

--- a/test/navigation/root_test.dart
+++ b/test/navigation/root_test.dart
@@ -12,7 +12,7 @@ import 'package:aspire/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(App());
+    await tester.pumpWidget(app);
 
     // Verify navigations
   });

--- a/test/profile/user_profile_test.dart
+++ b/test/profile/user_profile_test.dart
@@ -12,7 +12,7 @@ import 'package:aspire/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(App());
+    await tester.pumpWidget(app);
 
     // Verify navigations
   });


### PR DESCRIPTION
**Changes**
- created `CommonContext` that initializes screen size + theme colors
- update all instances in the codebase to use `ScreenSize` and `ThemeColors`
- deleted all instances of `MediaQuery` beyond the one defined in `CommonContext`
- simplify import statements to use `common.dart` widgets


**UI**
> No visible changes

**Notes**
- There are other constants defined in `ScreenSize` in the `CommonContext`.
- We can use these later to help us ensure our content never renders off the screen. For now, I just updated everything to use `width` and `height` as it originally did.
