### PR TITLE
feat: add industry + areas of interest fields on mentee sign-up form

### DIFF
--- a/lib/authentication/login.dart
+++ b/lib/authentication/login.dart
@@ -63,8 +63,6 @@ class _Login extends State<Login> {
 
   @override
   Widget build(BuildContext context) {
-    CommonContext().init(context);
-
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: GlobalHeader(
@@ -222,7 +220,6 @@ class _Login extends State<Login> {
         focusNode: emailAddressFocus,
         style: fieldTextStyle(color: ThemeColors.primary),
         decoration: fieldDecoration(
-          context,
           isFocused: isEmailAddressFocused,
           isInvalid: isEmailAddressInvalid,
           hintText: emailHint,
@@ -249,7 +246,6 @@ class _Login extends State<Login> {
         maxLines: 1,
         style: fieldTextStyle(color: ThemeColors.primary),
         decoration: fieldDecoration(
-          context,
           isFocused: isPasswordFocused,
           isInvalid: isPasswordInvalid,
           hintText: passwordHint,

--- a/lib/authentication/login_signup_funnel.dart
+++ b/lib/authentication/login_signup_funnel.dart
@@ -11,9 +11,7 @@ class LoginSignupFunnel extends StatelessWidget {
   LoginSignupFunnel({Key key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
-    CommonContext().init(context);
-    
+  Widget build(BuildContext context) {    
     return Scaffold(
       backgroundColor: Colors.white,
       body: Container(

--- a/lib/authentication/password/link_sent.dart
+++ b/lib/authentication/password/link_sent.dart
@@ -28,8 +28,6 @@ class _LinkSent extends State<LinkSent> {
 
   @override
   Widget build(BuildContext context) {
-    CommonContext().init(context);
-
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: GlobalHeader(
@@ -104,7 +102,6 @@ class _LinkSent extends State<LinkSent> {
         initialValue: widget.emailAddress,
         style: fieldTextStyle(color: Colors.grey),
         decoration: fieldDecoration(
-          context,
           isFocused: false,
           isInvalid: false,
           hintText: emailHint,

--- a/lib/authentication/password/reset_link.dart
+++ b/lib/authentication/password/reset_link.dart
@@ -34,8 +34,6 @@ class _ResetLink extends State<ResetLink> {
 
   @override
   Widget build(BuildContext context) {
-    CommonContext().init(context);
-
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: GlobalHeader(
@@ -105,7 +103,6 @@ class _ResetLink extends State<ResetLink> {
         attribute: 'emailAddress',
         autofocus: true, 
         decoration: fieldDecoration(
-          context,
           isFocused: true,
           isInvalid: isEmailAddressInvalid,
           hintText: emailHint,

--- a/lib/authentication/sign_up/funnel.dart
+++ b/lib/authentication/sign_up/funnel.dart
@@ -11,8 +11,6 @@ class SignUpFunnel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    CommonContext().init(context);
-
     return Scaffold(
       // TODO: Replace with primary when center ano image is updated
       backgroundColor: Color(0xFF0B0B33),

--- a/lib/authentication/sign_up/mentee_sign_up.dart
+++ b/lib/authentication/sign_up/mentee_sign_up.dart
@@ -228,24 +228,26 @@ class _MenteeSignUp extends State<MenteeSignUp> {
   Widget buildForm() {
     return Container(
       width: ScreenSize.width * 0.70,
-        child: FormBuilder(
-          key: _menteeSignUpFormKey,
-          child: SizedBox(
-            height: ScreenSize.height * 0.47,
-            child: Center( child: ListView(
-            padding: EdgeInsets.all(0.0),
-            scrollDirection: Axis.vertical,
-            shrinkWrap: true,
-            children: <Widget>[
-              buildFullNameField(),
-              buildEmailAddressField(),
-              buildPasswordField(),
-              buildIndustryField(),
-              buildAreasOfInterestSelector(),
-            ]
+      child: FormBuilder(
+        key: _menteeSignUpFormKey,
+        child: SizedBox(
+          height: ScreenSize.height * 0.47,
+          child: Center(
+            child: ListView(
+              padding: EdgeInsets.all(0.0),
+              scrollDirection: Axis.vertical,
+              shrinkWrap: true,
+              children: <Widget>[
+                buildFullNameField(),
+                buildEmailAddressField(),
+                buildPasswordField(),
+                buildIndustryField(),
+                buildAreasOfInterestSelector(),
+              ]
+            )
           )
         )
-      ))
+      )
     );
   }
 

--- a/lib/authentication/sign_up/mentee_sign_up.dart
+++ b/lib/authentication/sign_up/mentee_sign_up.dart
@@ -79,8 +79,6 @@ class _MenteeSignUp extends State<MenteeSignUp> {
 
   @override
   Widget build(BuildContext context) {
-    CommonContext().init(context);
-
     return GestureDetector(
       onTap: unfocusFields,
       child: Scaffold(
@@ -153,6 +151,7 @@ class _MenteeSignUp extends State<MenteeSignUp> {
           isEmailAddressInvalid = false;
           isPasswordInvalid = false;
           isIndustryInvalid = false;
+          isAreasOfInterestInvalid = false;
         });
       } on Exception catch (e) {
         print('Error: $e');
@@ -168,6 +167,7 @@ class _MenteeSignUp extends State<MenteeSignUp> {
           isEmailAddressInvalid = true;
           isPasswordInvalid = true;
           isIndustryInvalid = true;
+          isAreasOfInterestInvalid = true;
         });
     }
   }
@@ -275,7 +275,6 @@ class _MenteeSignUp extends State<MenteeSignUp> {
         focusNode: fullNameFocus,
         style: fieldTextStyle(color: ThemeColors.primary),
         decoration: fieldDecoration(
-          context,
           isFocused: isFullNameFocused,
           isInvalid: isFullNameInvalid,
           hintText: fullNameHint,
@@ -300,7 +299,6 @@ class _MenteeSignUp extends State<MenteeSignUp> {
         focusNode: emailAddressFocus,
         style: fieldTextStyle(color: ThemeColors.primary),
         decoration: fieldDecoration(
-          context,
           isFocused: isEmailAddressFocused,
           isInvalid: isEmailAddressInvalid,
           hintText: emailHint,
@@ -328,7 +326,6 @@ class _MenteeSignUp extends State<MenteeSignUp> {
         maxLines: 1,
         style: fieldTextStyle(color: ThemeColors.primary),
         decoration: fieldDecoration(
-          context,
           isFocused: isPasswordFocused,
           isInvalid: isPasswordInvalid,
           hintText: passwordHint,

--- a/lib/authentication/sign_up/mentee_sign_up.dart
+++ b/lib/authentication/sign_up/mentee_sign_up.dart
@@ -242,7 +242,7 @@ class _MenteeSignUp extends State<MenteeSignUp> {
                 buildEmailAddressField(),
                 buildPasswordField(),
                 buildIndustryField(),
-                buildAreasOfInterestSelector(),
+                buildAreasOfInterestSelector()
               ]
             )
           )

--- a/lib/common/circle_indicators.dart
+++ b/lib/common/circle_indicators.dart
@@ -9,8 +9,6 @@ class CircleIndicators extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    CommonContext().init(context);
-
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: buildCircles(context)

--- a/lib/common/common.dart
+++ b/lib/common/common.dart
@@ -1,7 +1,11 @@
 export 'circle_indicators.dart';
+export 'custom_field.dart';
 export 'footer_links.dart';
 export 'format_text.dart';
 export 'global_header.dart';
+export 'icon_data.dart';
 export 'info_border.dart';
+export 'list_picker.dart';
+export 'multiselect_modal.dart';
 export 'primary_button.dart';
 export 'styles.dart';

--- a/lib/common/custom_field.dart
+++ b/lib/common/custom_field.dart
@@ -30,6 +30,8 @@ class CustomField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    CommonContext().init(context);
+
     return isEnabled ? FormBuilderCustomField(
       attribute: attribute,
       initialValue: initialValue,
@@ -47,7 +49,7 @@ class CustomField extends StatelessWidget {
               icon: icon,
               errorText: field.errorText
             ),
-            baseStyle: fieldTextStyle(color: Theme.of(context).primaryColor),
+            baseStyle: fieldTextStyle(color: ThemeColors.primary),
             child: Container(
               height: 20.0,
               child: InkWell(
@@ -59,7 +61,7 @@ class CustomField extends StatelessWidget {
                   overflow: TextOverflow.ellipsis,
                   textColor: value == '' || value == null
                       ? Colors.grey
-                      : Theme.of(context).primaryColor
+                      : ThemeColors.primary
                 ),
               )
             ),

--- a/lib/common/custom_field.dart
+++ b/lib/common/custom_field.dart
@@ -30,8 +30,6 @@ class CustomField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    CommonContext().init(context);
-
     return isEnabled ? FormBuilderCustomField(
       attribute: attribute,
       initialValue: initialValue,
@@ -39,35 +37,36 @@ class CustomField extends StatelessWidget {
         FormBuilderValidators.required(),
       ],
       formField: FormField(
-        builder: (field) {
-          return InputDecorator(
-            isFocused: isFocused,
-            decoration: fieldDecoration(
-              context,
-              isFocused: isFocused,
-              isInvalid: isInvalid,
-              icon: icon,
-              errorText: field.errorText
-            ),
-            baseStyle: fieldTextStyle(color: ThemeColors.primary),
-            child: Container(
-              height: 20.0,
-              child: InkWell(
-                onTap: onTap,
-                child: FormatText(
-                  text: value == '' || value == null ? hintText : value,
-                  fontSize: 14.0,
-                  fontWeight: FontWeight.w500,
-                  overflow: TextOverflow.ellipsis,
-                  textColor: value == '' || value == null
-                      ? Colors.grey
-                      : ThemeColors.primary
-                ),
-              )
-            ),
-          );
-        }
+        builder: buildFormField
       )
     ) : SizedBox();
+  }
+
+  Widget buildFormField(FormFieldState<dynamic> field) {
+    return InputDecorator(
+      isFocused: isFocused,
+      decoration: fieldDecoration(
+        isFocused: isFocused,
+        isInvalid: isInvalid,
+        icon: icon,
+        errorText: field.errorText
+      ),
+      baseStyle: fieldTextStyle(color: ThemeColors.primary),
+      child: Container(
+        height: 20.0,
+        child: InkWell(
+          onTap: onTap,
+          child: FormatText(
+            text: value == '' || value == null ? hintText : value,
+            fontSize: 14.0,
+            fontWeight: FontWeight.w500,
+            overflow: TextOverflow.ellipsis,
+            textColor: value == '' || value == null
+                ? Colors.grey
+                : ThemeColors.primary
+          ),
+        )
+      ),
+    );
   }
 }

--- a/lib/common/custom_field.dart
+++ b/lib/common/custom_field.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+
+import './common.dart';
+
+class CustomField extends StatelessWidget {
+  final String attribute;
+  final String initialValue;
+  final bool isFocused;
+  final bool isEnabled;
+  final bool isInvalid;
+  final String hintText;
+  final IconData icon;
+  final String value;
+  final void Function() onTap;
+
+  CustomField({
+    Key key,
+    @required this.attribute,
+    @required this.initialValue,
+    @required this.isFocused,
+    @required this.isEnabled,
+    @required this.isInvalid,
+    @required this.hintText,
+    @required this.icon,
+    @required this.value,
+    @required this.onTap
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return isEnabled ? FormBuilderCustomField(
+      attribute: attribute,
+      initialValue: initialValue,
+      validators: [
+        FormBuilderValidators.required(),
+      ],
+      formField: FormField(
+        builder: (field) {
+          return InputDecorator(
+            isFocused: isFocused,
+            decoration: fieldDecoration(
+              context,
+              isFocused: isFocused,
+              isInvalid: isInvalid,
+              icon: icon,
+              errorText: field.errorText
+            ),
+            baseStyle: fieldTextStyle(color: Theme.of(context).primaryColor),
+            child: Container(
+              height: 20.0,
+              child: InkWell(
+                onTap: onTap,
+                child: FormatText(
+                  text: value == '' || value == null ? hintText : value,
+                  fontSize: 14.0,
+                  fontWeight: FontWeight.w500,
+                  overflow: TextOverflow.ellipsis,
+                  textColor: value == '' || value == null
+                      ? Colors.grey
+                      : Theme.of(context).primaryColor
+                ),
+              )
+            ),
+          );
+        }
+      )
+    ) : SizedBox();
+  }
+}

--- a/lib/common/global_header.dart
+++ b/lib/common/global_header.dart
@@ -19,7 +19,6 @@ class GlobalHeader extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     var showAction = actionText != null && onActionTap != null;
-    CommonContext().init(context);
 
     return AppBar(
       title: appBarTitle(), 

--- a/lib/common/icon_data.dart
+++ b/lib/common/icon_data.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/cupertino.dart';
+
+const IconData lockIconData = IconData(
+  0xf457,
+  fontFamily: CupertinoIcons.iconFont,
+  fontPackage: CupertinoIcons.iconFontPackage
+);
+
+const IconData briefCaseIconData = IconData(
+  0xf3ed,
+  fontFamily: CupertinoIcons.iconFont,
+  fontPackage: CupertinoIcons.iconFontPackage
+);
+
+const IconData lightBulbIconData = IconData(
+  0xf451,
+  fontFamily: CupertinoIcons.iconFont,
+  fontPackage: CupertinoIcons.iconFontPackage
+);
+
+const IconData chatIconData = IconData(
+  0xf3fb,
+  fontFamily: CupertinoIcons.iconFont,
+  fontPackage: CupertinoIcons.iconFontPackage
+);
+
+const IconData emailIconData = IconData(
+  0xf422,
+  fontFamily: CupertinoIcons.iconFont,
+  fontPackage: CupertinoIcons.iconFontPackage
+);
+
+const IconData phoneIconData = IconData(
+  0xf4b8,
+  fontFamily: CupertinoIcons.iconFont,
+  fontPackage: CupertinoIcons.iconFontPackage
+);
+
+const IconData webIconData = IconData(
+  0xf4d2,
+  fontFamily: CupertinoIcons.iconFont,
+  fontPackage: CupertinoIcons.iconFontPackage
+);
+
+const IconData headerEditIconData = IconData(
+  0xf417,
+  fontFamily: CupertinoIcons.iconFont,
+  fontPackage: CupertinoIcons.iconFontPackage
+);
+
+const IconData addIconData = IconData(
+  0xf2c7,
+  fontFamily: CupertinoIcons.iconFont,
+  fontPackage: CupertinoIcons.iconFontPackage
+);
+
+const IconData rowEditIconData = IconData(
+  0xf2bf,
+  fontFamily: CupertinoIcons.iconFont,
+  fontPackage: CupertinoIcons.iconFontPackage
+);
+

--- a/lib/common/list_picker.dart
+++ b/lib/common/list_picker.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_picker/flutter_picker.dart';
+
+import '../common/common.dart';
+import '../constants/constants.dart';
+
+class ListPicker {
+  final String titleText;
+  final List<String> data;
+  final List<int> selecteds;
+  final void Function(Picker, List<int>) onConfirm;
+
+  ListPicker({
+    @required this.titleText,
+    @required this.data,
+    @required this.selecteds,
+    @required this.onConfirm
+  });
+
+  Picker build(BuildContext context) {
+    return Picker(
+      adapter: PickerDataAdapter(data: getData(context)),
+      selecteds: selecteds,
+      hideHeader: false,
+      height: MediaQuery.of(context).size.height * 0.30,
+      itemExtent: 30.0,
+      magnification: 1.5,
+      squeeze: 0.80,
+      diameterRatio: 4.0,
+      onConfirm: onConfirm,
+      builderHeader: buildHeader
+    );
+  }
+
+  List<PickerItem<String>> getData(BuildContext context) {
+    return data.map((item) => PickerItem(
+      text: FormatText(
+        text: item,
+        textColor: Theme.of(context).primaryColor, 
+        fontSize: 15.0,
+        fontWeight: FontWeight.normal
+      ),
+      value: item
+    )).toList();
+  }
+
+  Widget buildHeader(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border(
+          bottom: BorderSide(
+            color: Colors.grey,
+            width: 0.3
+          ),
+        ),
+      ),
+      padding: EdgeInsets.all(20.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: <Widget>[
+          buildTitle(context),
+          buildConfirmAction(context)
+        ]
+      )
+    );
+  }
+
+  Widget buildTitle(BuildContext context) {
+    return FormatText(
+      text: titleText,
+      textColor: Theme.of(context).primaryColor, 
+      fontSize: 15.0,
+      fontWeight: FontWeight.w600
+    );
+  }
+
+  Widget buildConfirmAction(BuildContext context) {
+    return InkWell(
+      onTap: () => build(context).doConfirm(context),
+      child: FormatText(
+        text: confirmModalAction,
+        textColor: Theme.of(context).accentColor, 
+        fontSize: 15.0,
+        fontWeight: FontWeight.w600
+      ),
+    );
+  }
+}

--- a/lib/common/list_picker.dart
+++ b/lib/common/list_picker.dart
@@ -19,8 +19,6 @@ class ListPicker {
   });
 
   Picker build(BuildContext context) {
-    CommonContext().init(context);
-
     return Picker(
       adapter: PickerDataAdapter(data: getData()),
       selecteds: selecteds,

--- a/lib/common/list_picker.dart
+++ b/lib/common/list_picker.dart
@@ -19,11 +19,13 @@ class ListPicker {
   });
 
   Picker build(BuildContext context) {
+    CommonContext().init(context);
+
     return Picker(
-      adapter: PickerDataAdapter(data: getData(context)),
+      adapter: PickerDataAdapter(data: getData()),
       selecteds: selecteds,
       hideHeader: false,
-      height: MediaQuery.of(context).size.height * 0.30,
+      height: ScreenSize.height * 0.30,
       itemExtent: 30.0,
       magnification: 1.5,
       squeeze: 0.80,
@@ -33,11 +35,11 @@ class ListPicker {
     );
   }
 
-  List<PickerItem<String>> getData(BuildContext context) {
+  List<PickerItem<String>> getData() {
     return data.map((item) => PickerItem(
       text: FormatText(
         text: item,
-        textColor: Theme.of(context).primaryColor, 
+        textColor: ThemeColors.primary, 
         fontSize: 15.0,
         fontWeight: FontWeight.normal
       ),
@@ -60,17 +62,17 @@ class ListPicker {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[
-          buildTitle(context),
+          buildTitle(),
           buildConfirmAction(context)
         ]
       )
     );
   }
 
-  Widget buildTitle(BuildContext context) {
+  Widget buildTitle() {
     return FormatText(
       text: titleText,
-      textColor: Theme.of(context).primaryColor, 
+      textColor: ThemeColors.primary, 
       fontSize: 15.0,
       fontWeight: FontWeight.w600
     );
@@ -81,7 +83,7 @@ class ListPicker {
       onTap: () => build(context).doConfirm(context),
       child: FormatText(
         text: confirmModalAction,
-        textColor: Theme.of(context).accentColor, 
+        textColor: ThemeColors.accent, 
         fontSize: 15.0,
         fontWeight: FontWeight.w600
       ),

--- a/lib/common/multiselect_modal.dart
+++ b/lib/common/multiselect_modal.dart
@@ -26,8 +26,6 @@ class MultiSelectModal extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    CommonContext().init(context);
-
     return SmartSelect<String>.multiple(
       padding: EdgeInsets.all(0),
       title: hintText,

--- a/lib/common/multiselect_modal.dart
+++ b/lib/common/multiselect_modal.dart
@@ -26,6 +26,8 @@ class MultiSelectModal extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    CommonContext().init(context);
+
     return SmartSelect<String>.multiple(
       padding: EdgeInsets.all(0),
       title: hintText,
@@ -39,13 +41,13 @@ class MultiSelectModal extends StatelessWidget {
       onChange: onConfirm,
       modalType: SmartSelectModalType.bottomSheet,
       choiceType: SmartSelectChoiceType.chips,
-      modalConfig: getModalConfig(context),
-      choiceConfig: getChoiceConfig(context),
+      modalConfig: getModalConfig(),
+      choiceConfig: getChoiceConfig(),
       builder: field
     );
   }
 
-  SmartSelectModalConfig getModalConfig(BuildContext context) {
+  SmartSelectModalConfig getModalConfig() {
     return SmartSelectModalConfig(
       useConfirmation: true,
       headerStyle: SmartSelectModalHeaderStyle(
@@ -57,7 +59,7 @@ class MultiSelectModal extends StatelessWidget {
           ),
         ),
         textStyle: modalTextStyle(
-          color: Theme.of(context).primaryColor,
+          color: ThemeColors.primary,
           isButton: true
         )
       ),
@@ -74,7 +76,7 @@ class MultiSelectModal extends StatelessWidget {
         onTap: onConfirm,
         child: FormatText(
           text: confirmModalAction,
-          textColor: Theme.of(context).accentColor, 
+          textColor: ThemeColors.accent, 
           fontSize: 15.0,
           fontWeight: FontWeight.w600
         )
@@ -82,13 +84,13 @@ class MultiSelectModal extends StatelessWidget {
     );
   }
 
-  SmartSelectChoiceConfig<String> getChoiceConfig(BuildContext context) {
+  SmartSelectChoiceConfig<String> getChoiceConfig() {
     return SmartSelectChoiceConfig(
       style: SmartSelectChoiceStyle(
         activeColor: Colors.white,
-        inactiveColor: Theme.of(context).accentColor,
+        inactiveColor: ThemeColors.accent,
         inactiveTrackColor: Colors.white,
-        checkColor:Theme.of(context).accentColor,
+        checkColor:ThemeColors.accent,
         titleStyle: fieldTextStyle(),
       )
     );

--- a/lib/common/multiselect_modal.dart
+++ b/lib/common/multiselect_modal.dart
@@ -54,7 +54,7 @@ class MultiSelectModal extends StatelessWidget {
           bottom: BorderSide(
             color: Colors.grey,
             width: 0.3
-          ),
+          )
         ),
         textStyle: modalTextStyle(
           color: ThemeColors.primary,

--- a/lib/common/multiselect_modal.dart
+++ b/lib/common/multiselect_modal.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:smart_select/smart_select.dart';
+
+import '../constants/constants.dart';
+import './common.dart';
+
+class MultiSelectModal extends StatelessWidget {
+  final String hintText;
+  final List<String> values;
+  final List<String> options;
+  final Function(List<String>) onConfirm;
+  final Function(
+    BuildContext,
+    SmartSelectState<String>,
+    void Function(BuildContext)
+  ) field;
+  
+  MultiSelectModal({
+    Key key,
+    @required this.hintText,
+    @required this.values,
+    @required this.options,
+    @required this.onConfirm,
+    @required this.field
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SmartSelect<String>.multiple(
+      padding: EdgeInsets.all(0),
+      title: hintText,
+      dense: true,
+      value: values,
+      options: SmartSelectOption.listFrom<String, String>(
+        source: options,
+        value: (index, item) => item,
+        title: (index, item) => item,
+      ),
+      onChange: onConfirm,
+      modalType: SmartSelectModalType.bottomSheet,
+      choiceType: SmartSelectChoiceType.chips,
+      modalConfig: getModalConfig(context),
+      choiceConfig: getChoiceConfig(context),
+      builder: field
+    );
+  }
+
+  SmartSelectModalConfig getModalConfig(BuildContext context) {
+    return SmartSelectModalConfig(
+      useConfirmation: true,
+      headerStyle: SmartSelectModalHeaderStyle(
+        elevation: 0.0,
+        shape: Border(
+          bottom: BorderSide(
+            color: Colors.grey,
+            width: 0.3
+          ),
+        ),
+        textStyle: modalTextStyle(
+          color: Theme.of(context).primaryColor,
+          isButton: true
+        )
+      ),
+      style: SmartSelectModalStyle(backgroundColor: Colors.white),
+      confirmationBuilder: buildConfirmAction,
+    );
+  }
+
+  Widget buildConfirmAction(BuildContext context, Function onConfirm) {
+    return Container(
+      alignment: Alignment.center,
+      padding: (EdgeInsets.only(right: 10.0)),
+      child: InkWell(
+        onTap: onConfirm,
+        child: FormatText(
+          text: confirmModalAction,
+          textColor: Theme.of(context).accentColor, 
+          fontSize: 15.0,
+          fontWeight: FontWeight.w600
+        )
+      )
+    );
+  }
+
+  SmartSelectChoiceConfig<String> getChoiceConfig(BuildContext context) {
+    return SmartSelectChoiceConfig(
+      style: SmartSelectChoiceStyle(
+        activeColor: Colors.white,
+        inactiveColor: Theme.of(context).accentColor,
+        inactiveTrackColor: Colors.white,
+        checkColor:Theme.of(context).accentColor,
+        titleStyle: fieldTextStyle(),
+      )
+    );
+  }
+}

--- a/lib/common/primary_button.dart
+++ b/lib/common/primary_button.dart
@@ -21,8 +21,6 @@ class PrimaryButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    CommonContext().init(context);
-
     return MaterialButton(
       minWidth: minWidth ?? ScreenSize.width * 0.50,
       height: height,

--- a/lib/common/styles.dart
+++ b/lib/common/styles.dart
@@ -3,8 +3,7 @@ import 'package:google_fonts/google_fonts.dart';
 
 import './common_context.dart';
 
-InputDecoration fieldDecoration(
-  BuildContext context, {
+InputDecoration fieldDecoration({
     String hintText,
     String errorText,
     IconData icon,

--- a/lib/common/styles.dart
+++ b/lib/common/styles.dart
@@ -4,6 +4,7 @@ import 'package:google_fonts/google_fonts.dart';
 InputDecoration fieldDecoration(
   BuildContext context, {
     String hintText,
+    String errorText,
     IconData icon,
     bool isFocused,
     bool isInvalid
@@ -33,7 +34,11 @@ InputDecoration fieldDecoration(
       ),
       borderRadius: BorderRadius.all(Radius.zero),
     ),
-    errorStyle: fieldTextStyle(fontSize: 13.0, color: Colors.red),
+    errorText: errorText,
+    errorStyle: fieldTextStyle(
+      fontSize: 13.0,
+      color: Colors.red
+    ),
     hintText: hintText,
     hintStyle: fieldTextStyle(),
     prefixIcon: Icon(
@@ -54,5 +59,15 @@ TextStyle fieldTextStyle({double fontSize, Color color}) =>
       fontSize: fontSize ?? 14.0,  
       fontWeight: FontWeight.w500,
       height: 1.2
+    )
+  );
+
+TextStyle modalTextStyle({bool isButton, Color color}) =>
+  GoogleFonts.muli(
+    textStyle: TextStyle(
+      color: color ?? Colors.grey, 
+      letterSpacing: .5, 
+      fontSize: 15.0,
+      fontWeight: isButton ? FontWeight.w600 : FontWeight.normal
     )
   );

--- a/lib/constants/authentication_constants.dart
+++ b/lib/constants/authentication_constants.dart
@@ -2,6 +2,8 @@
 const String fullNameHint = 'Enter your full name';
 const String emailHint = 'Enter your email';
 const String passwordHint = 'Enter your password';
+const String industryHint = 'Select your industry';
+const String areasOfInterestHint = 'Select your areas of interest';
 const String forgotPassword = 'Forgot password?';
 const String newPasswordHint = 'Enter your new password';
 const String confirmPasswordHint = 'Confirm your password';

--- a/lib/constants/common_constants.dart
+++ b/lib/constants/common_constants.dart
@@ -1,18 +1,21 @@
 import 'package:flutter/material.dart';
 
-const appName = "aspire";
-const nextButtonText = "Next";
+const String appName = 'aspire';
+const String nextButtonText = 'Next';
 
 // Global header
-const addAction = 'Add';
-const skipAction = 'Skip';
-const filterAction = 'Filter';
-const signInAction = 'Sign in';
-const signUpAction = 'Sign up';
-const loginAction = 'Login';
+const String addAction = 'Add';
+const String skipAction = 'Skip';
+const String filterAction = 'Filter';
+const String signInAction = 'Sign in';
+const String signUpAction = 'Sign up';
+const String loginAction = 'Login';
 
-const globalHeaderFontSize = 22.0;
-const globalHeaderActionsFontSize = 16.0; 
+const double globalHeaderFontSize = 22.0;
+const double globalHeaderActionsFontSize = 16.0; 
+
+// Modal
+const String confirmModalAction = 'Confirm';
 
  // User types
 enum UserType {

--- a/lib/constants/constants.dart
+++ b/lib/constants/constants.dart
@@ -3,6 +3,7 @@ export 'authentication_constants.dart';
 export 'chat_constants.dart';
 export 'common_constants.dart';
 export 'ftu_constants.dart';
+export 'industry_constants.dart';
 export 'pairings_constants.dart';
 export 'profile_constants.dart';
 export 'theme_constants.dart';

--- a/lib/constants/industry_constants.dart
+++ b/lib/constants/industry_constants.dart
@@ -1,0 +1,49 @@
+import '../models/models.dart';
+
+List<Industry> industries = [
+  Industry(
+    name: 'Business',
+    areas: [
+      'Accounting',
+      'Entrepreneurship',
+      'Finance',
+      'Human resources',
+      'Insurance',
+      'Marketing',
+      'Real estate'
+    ]
+  ),
+  Industry(
+    name: 'Communications',
+    areas: [
+      'Advertising',
+      'Journalism',
+      'Public relations',
+      'Publishing'
+    ]
+  ),
+  Industry(
+    name: 'Health & Medicine',
+    areas: [
+      'Chiropractic',
+      'Dentistry',
+      'Mental health',
+      'Nursing',
+      'Nutrition',
+      'Optometry',
+      'Pharmacy'
+    ]
+  ),
+  Industry(
+    name: 'Technology',
+    areas: [
+      'Artificial intellligence',
+      'Cloud computing',
+      'Cyber-security',
+      'Data science',
+      'Machine learning',
+      'Software development',
+      'Web development'
+    ]
+  )
+];

--- a/lib/constants/profile_constants.dart
+++ b/lib/constants/profile_constants.dart
@@ -1,15 +1,6 @@
 // Widget dimensions
 const double profileHeaderHeight = 160.0;
 
-// Cupertino icon code points
-const int plusIconCodePoint = 0xf2c7;
-const int rowEditIconCodePoint = 0xf2bf;
-const int headerEditIconCodePoint = 0xf417;
-const int chatIconCodePoint = 0xf3fb;
-const int emailIconCodePoint = 0xf422;
-const int phoneIconCodePoint = 0xf4b8;
-const int webIconCodePoint = 0xf4d2;
-
 // Section titles
 const String sectionTitleSummary = 'Summary';
 const String sectionTitleEducation = 'Education';

--- a/lib/ftu/onboarding/intro.dart
+++ b/lib/ftu/onboarding/intro.dart
@@ -10,9 +10,7 @@ class OnboardingIntro extends StatelessWidget {
   OnboardingIntro({Key key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
-    CommonContext().init(context);
-  
+  Widget build(BuildContext context) {  
     return Scaffold(
       backgroundColor: ThemeColors.primary,
       body: Container(

--- a/lib/ftu/onboarding/steps.dart
+++ b/lib/ftu/onboarding/steps.dart
@@ -26,9 +26,7 @@ class _OnboardingSteps extends State<OnboardingSteps> {
   }
 
   @override
-  Widget build(BuildContext context) {
-    CommonContext().init(context);
-    
+  Widget build(BuildContext context) {    
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: buildHeader(),

--- a/lib/models/entities/entities.dart
+++ b/lib/models/entities/entities.dart
@@ -1,4 +1,5 @@
 export 'contact.dart';
+export 'industry.dart';
 export 'job.dart';
 export 'match.dart';
 export 'message.dart';

--- a/lib/models/entities/industry.dart
+++ b/lib/models/entities/industry.dart
@@ -1,0 +1,48 @@
+import 'dart:convert';
+import 'package:meta/meta.dart';
+
+@immutable
+class Industry {
+  final String name;
+  final List<String> areas;
+
+  const Industry({
+    @required this.name,
+    @required this.areas,
+  });
+
+  factory Industry.initial() {
+    return Industry(
+      name: '',
+      areas: []
+    );
+  }
+
+  Industry copyWith({
+    String name,
+    List<String> areas,
+  }) {
+    return Industry(
+      name: name ?? this.name,
+      areas: areas ?? this.areas
+    );
+  }
+
+  static Industry fromJson(dynamic json) {
+    var areasJson = json['areas'] as List;
+    return Industry(
+      name: json["name"] as String,
+      areas: areasJson?.map((area) => area as String)?.toList()
+    );
+  }
+
+  dynamic toJson() => {
+    'name': name,
+    'areas': areas?.map((area) => area)?.toList()
+  };
+
+  @override
+  String toString() {
+    return 'Industry: ${JsonEncoder.withIndent('  ').convert(this)}';
+  }
+}

--- a/lib/models/entities/user.dart
+++ b/lib/models/entities/user.dart
@@ -12,6 +12,7 @@ class User {
   final UserType type;
   final bool isVerified;
   final bool isFtu;
+  final Industry industry;
   final String fullName;
   final String summary;
   final List<School> schools;
@@ -24,6 +25,7 @@ class User {
     @required this.type,
     @required this.isVerified,
     @required this.isFtu,
+    @required this.industry,
     @required this.contact,
     this.fullName,
     this.summary,
@@ -38,6 +40,7 @@ class User {
       type: null,
       isVerified: false,
       isFtu: true,
+      industry: Industry.initial(),
       fullName: '',
       summary: '',
       schools: [],
@@ -52,6 +55,7 @@ class User {
     UserType type,
     bool isVerified,
     bool isFtu,
+    Industry industry,
     String fullName,
     String summary,
     List<School> schools,
@@ -64,6 +68,7 @@ class User {
       type: type ?? this.type,
       isVerified: isVerified ?? this.isVerified,
       isFtu: isFtu ?? this.isFtu,
+      industry: industry ?? this.industry,
       fullName: fullName ?? this.fullName,
       summary: summary ?? this.summary,
       schools: schools ?? this.schools,
@@ -82,6 +87,7 @@ class User {
       type: parseUserTypeToValue(json["type"]),
       isVerified: json["isVerified"] as bool,
       isFtu: json["isFtu"] as bool,
+      industry: Industry.fromJson(json["industry"]),
       fullName: json["fullName"] as String,
       summary: json["summary"] as String,
       schools: schoolsJson?.map(School.fromJson)?.toList(),
@@ -96,6 +102,7 @@ class User {
     'type': parseUserTypeToString(type),
     'isVerified': isVerified,
     'isFtu': isFtu,
+    'industry': industry.toJson(),
     'fullName': fullName,
     'summary': summary,
     'schools': schools?.map((school) => school.toJson())?.toList(),

--- a/lib/navigation/root.dart
+++ b/lib/navigation/root.dart
@@ -6,6 +6,7 @@ import 'package:redux/redux.dart';
 
 import '../actions/actions.dart';
 import '../authentication/firebase_authentication.dart';
+import '../common/common.dart';
 import '../constants/common_constants.dart';
 import '../ftu/onboarding/intro.dart';
 import '../models/models.dart';
@@ -58,7 +59,9 @@ class _RootState extends State<Root>{
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context) {   
+    CommonContext().init(context); 
+
     return CustomSplash(
       imagePath: 'images/splash_screen_icon.png', 
       backGroundColor: Color(0xFF0A0B33),

--- a/lib/pairings/pairings.dart
+++ b/lib/pairings/pairings.dart
@@ -8,8 +8,6 @@ class Pairings extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    CommonContext().init(context);
-
     return Scaffold(
       appBar: GlobalHeader(),
       backgroundColor: Colors.white,

--- a/lib/profile/common/date_picker.dart
+++ b/lib/profile/common/date_picker.dart
@@ -21,8 +21,6 @@ class DatePicker {
   });
 
   Picker build(BuildContext context) {
-    CommonContext().init(context);
-
     return Picker(
       adapter: DateTimePickerAdapter(
         value: initialValue,

--- a/lib/profile/common/list_picker.dart
+++ b/lib/profile/common/list_picker.dart
@@ -29,9 +29,7 @@ class ListPicker {
     )).toList();
   }
 
-  Picker build(BuildContext context) {
-    CommonContext().init(context);
-    
+  Picker build(BuildContext context) {    
     return Picker(
       adapter: PickerDataAdapter(data: getData()),
       selecteds: selecteds,

--- a/lib/profile/common/section.dart
+++ b/lib/profile/common/section.dart
@@ -11,7 +11,6 @@ class Section extends StatelessWidget {
   
   @override
   Widget build(BuildContext context) {
-    CommonContext().init(context);
 
     final sectionTheme = Theme.of(context).copyWith(
       dividerColor: Colors.transparent,

--- a/lib/profile/common/styles.dart
+++ b/lib/profile/common/styles.dart
@@ -2,7 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
-import '../../constants/profile_constants.dart';
+import '../../common/common.dart';
 
 TextStyle fieldTextStyle = GoogleFonts.muli(
   textStyle: TextStyle(
@@ -49,19 +49,9 @@ InputDecoration fieldDecoration({String errorText}) => InputDecoration(
 
 
 Icon addIcon = Icon(
-  IconData(
-    plusIconCodePoint,
-    fontFamily: CupertinoIcons.iconFont,
-    fontPackage: CupertinoIcons.iconFontPackage
-  ),
+  addIconData,
   color: Colors.black54,
   size: 20.0,
-);
-
-IconData editIconInRow = IconData(
-  rowEditIconCodePoint,
-  fontFamily: CupertinoIcons.iconFont,
-  fontPackage: CupertinoIcons.iconFontPackage
 );
 
 Widget editButtonInRow = Container(
@@ -70,7 +60,7 @@ Widget editButtonInRow = Container(
     left: 10.0
   ),
   child: Icon(
-    editIconInRow,
+    rowEditIconData,
     color: Colors.black54,
     size: 20.0,
   )

--- a/lib/profile/view_profile/header.dart
+++ b/lib/profile/view_profile/header.dart
@@ -3,6 +3,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+import '../../common/common.dart';
 import '../../constants/profile_constants.dart';
 import '../save_profile/save_profile.dart';
  
@@ -86,17 +87,12 @@ class ProfileHeader extends StatelessWidget {
   }
 
   buildEditButton(BuildContext context){
-    var edit = IconData(
-      headerEditIconCodePoint,
-      fontFamily: CupertinoIcons.iconFont,
-      fontPackage: CupertinoIcons.iconFontPackage
-    );
     return InkWell(
       onTap: () => handleEditTap(context),
       child: Container(
         padding: EdgeInsets.all(20.0),
         child: Icon(
-          edit,
+          headerEditIconData,
           color: Colors.white,
           size: 30.0,
         )

--- a/lib/profile/view_profile/header.dart
+++ b/lib/profile/view_profile/header.dart
@@ -20,8 +20,6 @@ class ProfileHeader extends StatelessWidget {
   
   @override
   Widget build(BuildContext context) {
-    CommonContext().init(context);
-
     return Container(
       width: ScreenSize.width, 
       height: profileHeaderHeight,

--- a/lib/profile/view_profile/sections/contact.dart
+++ b/lib/profile/view_profile/sections/contact.dart
@@ -5,6 +5,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../chat/chat_messenger.dart';
+import '../../../common/common.dart';
 import '../../../constants/profile_constants.dart';
 import '../../../models/models.dart';
 import '../../../selectors/selectors.dart';
@@ -19,30 +20,6 @@ class ProfileContact extends StatelessWidget {
   ProfileContact(
     {Key key, @required this.user, this.matchId, this.viewOnly}
   ) : super(key: key);
-
-  final IconData chat = IconData(
-    chatIconCodePoint,
-    fontFamily: CupertinoIcons.iconFont,
-    fontPackage: CupertinoIcons.iconFontPackage
-  );
-  
-  final IconData email = IconData(
-    emailIconCodePoint,
-    fontFamily: CupertinoIcons.iconFont,
-    fontPackage: CupertinoIcons.iconFontPackage
-  );
-
-  final IconData phone = IconData(
-    phoneIconCodePoint,
-    fontFamily: CupertinoIcons.iconFont,
-    fontPackage: CupertinoIcons.iconFontPackage
-  );
-
-  final IconData web = IconData(
-    webIconCodePoint,
-    fontFamily: CupertinoIcons.iconFont,
-    fontPackage: CupertinoIcons.iconFontPackage
-  );
 
   @override
   Widget build(BuildContext context) {
@@ -60,28 +37,28 @@ class ProfileContact extends StatelessWidget {
         if (!viewOnly) 
           buildInfoRow(
             context, 
-            chat, 
+            chatIconData, 
             contactChat, 
             contactChatSubtitle,
             () => handleChatTap(context)
           ),
         buildInfoRow(
           context, 
-          email, 
+          emailIconData, 
           contactEmailAddress, 
           user.contact.emailAddress,
           handleEmailTap
         ),
         buildInfoRow(
           context,
-          phone,
+          phoneIconData,
           contactPhoneNumber,
           user.contact.phoneNumber,
           handlePhoneTap
         ),
         buildInfoRow(
           context,
-          web,
+          webIconData,
           contactWebsite,
           user.contact.website,
           handleWebsiteTap

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -45,12 +45,18 @@ Future<QuerySnapshot> getMentors() async {
 Future<void> addMentee(
   String id, {
     String emailAddress,
-    String fullName
+    String fullName,
+    String industry,
+    List<String> areasOfInterest
   }
 ) async {
   var user = User.initial().copyWith(
     id: id,
     type: UserType.mentee,
+    industry: Industry(
+      name: industry,
+      areas: areasOfInterest
+    ),
     fullName: fullName,
     contact: Contact.initial().copyWith(
       emailAddress: emailAddress

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -450,6 +450,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.8"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
   path:
     dependency: transitive
     description:
@@ -555,6 +562,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.13"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.3.1"
   pub_semver:
     dependency: transitive
     description:
@@ -665,6 +679,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
+  smart_select:
+    dependency: "direct main"
+    description:
+      name: smart_select
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.3"
   source_span:
     dependency: transitive
     description:
@@ -693,6 +714,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.3"
+  sticky_headers:
+    dependency: transitive
+    description:
+      name: sticky_headers
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.8+1"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   redux_persist: ^0.8.4
   redux_persist_flutter: ^0.8.2
   redux_logging: ^0.4.0
+  smart_select: ^3.0.3
   url_launcher: ^5.4.10
 
 


### PR DESCRIPTION
**Changes**
- Added `industry` and `areasOfExpertise` fields on the mentee sign-up form. Note that the `areasOfExpertise` field is hidden when the `industry` field value is null.
- Added `industry` attribute as `Industry` class to user entity.
- Created `industry_constants.dart` and added starter industries; Feel free to add more!
- Deleted `CommonContext` init calls in all widgets except in `root.dart`.

**TODO:**
- Handle form responsiveness. Temporary workaround: Made the form widget scrollable for now.
- Add more industries.

**UI**

On iPhone 11 Pro Max:
> <img src="https://user-images.githubusercontent.com/25041263/89150904-ea01ab80-d51c-11ea-9f5d-a6791193a42c.gif" width="300px"/>

On iPhone SE:
>  <img src="https://user-images.githubusercontent.com/25041263/89150969-0aca0100-d51d-11ea-97b3-bb8ff68cf392.gif" width="250px"/>

