### PR TITLE
fix: theme global header back button and allow back for signup/login

### DIFF
--- a/lib/authentication/login_signup_funnel.dart
+++ b/lib/authentication/login_signup_funnel.dart
@@ -88,7 +88,7 @@ class LoginSignupFunnel extends StatelessWidget {
       child: PrimaryButton(
         text: loginButtonText,
         isLight: false,
-        onPressed: () => Navigator.pushReplacement(
+        onPressed: () => Navigator.push(
           context, MaterialPageRoute(
             builder: (context) => Login()
           )
@@ -103,7 +103,7 @@ class LoginSignupFunnel extends StatelessWidget {
       child: PrimaryButton(
         text: createAccountButtonText,
         isLight: true,
-        onPressed: () => Navigator.pushReplacement(
+        onPressed: () => Navigator.push(
           context, MaterialPageRoute(
             builder: (context) => SignUpFunnel()
           )

--- a/lib/authentication/sign_up/funnel.dart
+++ b/lib/authentication/sign_up/funnel.dart
@@ -122,7 +122,7 @@ class SignUpFunnel extends StatelessWidget {
       PrimaryButton(
         text: isMentorAction,
         isLight: isLight, 
-        onPressed: () => Navigator.pushReplacement(
+        onPressed: () => Navigator.push(
           context, MaterialPageRoute(
             builder: (context) => MentorSignUp()
           )
@@ -131,7 +131,7 @@ class SignUpFunnel extends StatelessWidget {
       PrimaryButton(
         text: isMenteeAction,
         isLight: isLight, 
-        onPressed: () => Navigator.pushReplacement(
+        onPressed: () => Navigator.push(
           context, MaterialPageRoute(
             builder: (context) => MenteeSignUp()
           )

--- a/lib/common/global_header.dart
+++ b/lib/common/global_header.dart
@@ -19,9 +19,12 @@ class GlobalHeader extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     var showAction = actionText != null && onActionTap != null;
-
+    var showBackButton = Navigator.canPop(context);
     return AppBar(
       title: appBarTitle(), 
+      leading: showBackButton ? 
+        BackButton(color: isLight ? Colors.white : Colors.black) :
+        null,
       actions: <Widget>[appBarAction(context, isVisible: showAction)],
       backgroundColor: Colors.transparent,
       centerTitle: false,


### PR DESCRIPTION
**Changes**
- Color the global header back button based on isLight
- Provide back button for signup/login

**UI**
> ![Screen Shot 2020-08-04 at 3 53 34 PM](https://user-images.githubusercontent.com/43127491/89348965-ad43ca80-d66a-11ea-8e18-d2c70e55ed1f.png)

