### PR TITLE
feat: add cards animation

### DIFF
--- a/lib/constants/pairings_constants.dart
+++ b/lib/constants/pairings_constants.dart
@@ -1,6 +1,12 @@
 const String readMoreButtonText = 'Read more';
-
-const dummyCard = {
+const String dummySummary = """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas suscipit fringilla purus, sed euismod odio. Nullam quam odio, ultrices at mi id, ornare lobortis diam. Quisque ultricies sem et magna rhoncus accumsan.""";
+const dummyCard = [
+  {
   "name": "Helen Gezahegn", 
-  "description": """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas suscipit fringilla purus, sed euismod odio. Nullam quam odio, ultrices at mi id, ornare lobortis diam. Quisque ultricies sem et magna rhoncus accumsan."""
-};
+  "description": dummySummary
+  },
+  {
+  "name": "Lorem Ipsum", 
+  "description": dummySummary
+  }
+];

--- a/lib/pairings/cards.dart
+++ b/lib/pairings/cards.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+
+import '../common/common.dart';
+import '../constants/constants.dart';
+
+class Cards extends StatelessWidget {
+  const Cards({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return buildCards();
+  }
+
+  Widget buildCards() {
+    return Container(
+      width: ScreenSize.width * 0.80,
+      height: ScreenSize.height * 0.42,
+      decoration: buildCardContainer(), 
+      child: Stack(
+        overflow: Overflow.visible, 
+        alignment: Alignment.center, 
+        children: [
+          buildCurrentCard(), 
+          Positioned(
+            top: ScreenSize.height * 0.39, 
+            child: buildReadMoreButton()
+          )
+        ]
+      )
+    );
+  }
+
+  PrimaryButton buildReadMoreButton() {
+    return PrimaryButton(
+      isLight: true,
+      text: readMoreButtonText,
+      onPressed: () => print("Read more pressed")
+    );
+  }
+
+  Widget buildCurrentCard() {
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        vertical: ScreenSize.height * 0.02, 
+        horizontal: ScreenSize.width * 0.05
+      ),
+      child: Column(
+        children: [
+          buildCardHeader(),
+          buildCardBody(), 
+          Spacer(), 
+          buildCardFooter()
+        ]
+      )
+    );
+  }
+
+  BoxDecoration buildCardContainer() {
+    return BoxDecoration(
+      border: Border.all(
+        color: ThemeColors.accent,
+        width: 1.0,
+        style: BorderStyle.solid
+      ),
+      color: Colors.transparent,
+      shape: BoxShape.rectangle, 
+      borderRadius: BorderRadius.all(Radius.circular(20))
+    );
+  }
+
+  Row buildCardHeader() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: ScreenSize.width * 0.10, 
+          height: ScreenSize.height * 0.10,
+          decoration: BoxDecoration(
+            color: Colors.grey[200], 
+            shape: BoxShape.circle
+          )
+        ), 
+        Padding(
+          padding: EdgeInsets.only(top: ScreenSize.height * 0.03), 
+          child: FormatText(
+            text: dummyCard["name"],
+            fontSize: 22.0
+          )
+        )
+      ]
+    );
+  }
+
+  FormatText buildCardBody() {
+    return FormatText(
+      text: dummyCard["description"], 
+      fontSize: 12.0,
+      fontWeight: FontWeight.w300,
+      fontHeight: 1.6
+    );
+  }
+  
+  Row buildCardFooter() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        InkWell(
+          onTap: () => print("Arrow pressed"),
+          child: Image.asset(
+            'images/right_arrow.png', 
+            height: ScreenSize.height * 0.015
+          )
+        ),
+        IconButton(
+          icon: Icon(Icons.favorite),
+          iconSize: ScreenSize.height * 0.03, 
+          color: ThemeColors.accent,
+          onPressed: () => print("Heart pressed"),
+        )
+      ]
+    );
+  }
+
+}

--- a/lib/pairings/cards.dart
+++ b/lib/pairings/cards.dart
@@ -1,14 +1,46 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animator/flutter_animator.dart';
 
 import '../common/common.dart';
 import '../constants/constants.dart';
 
-class Cards extends StatelessWidget {
+class Cards extends StatefulWidget {
   const Cards({Key key}) : super(key: key);
+  
+
+  @override
+  State<StatefulWidget> createState() => _Cards();
+}
+
+class _Cards extends State<Cards> {
+  int matchIndex;
+  final GlobalKey<InOutAnimationState> inOutAnimationCard = 
+    GlobalKey<InOutAnimationState>();
+
+  @override
+  void initState() {
+    super.initState();
+
+    matchIndex = 0;
+  }
 
   @override
   Widget build(BuildContext context) {
-    return buildCards();
+    return InOutAnimation(
+      key: inOutAnimationCard,
+      inDefinition: SlideInRightAnimation(),
+      outDefinition: SlideOutLeftAnimation(),
+      child: buildCards()
+    );
+  }
+
+  void getNextCard() async {
+    inOutAnimationCard.currentState.animateOut();
+    await Future.delayed(Duration(milliseconds: 500));
+    matchIndex == 1 
+      ? setState(() { matchIndex = 0; }) 
+      : setState(() { matchIndex += 1; });
+    inOutAnimationCard.currentState.animateIn();
   }
 
   Widget buildCards() {
@@ -20,7 +52,7 @@ class Cards extends StatelessWidget {
         overflow: Overflow.visible, 
         alignment: Alignment.center, 
         children: [
-          buildCurrentCard(), 
+          buildCardContent(), 
           Positioned(
             top: ScreenSize.height * 0.39, 
             child: buildReadMoreButton()
@@ -38,7 +70,7 @@ class Cards extends StatelessWidget {
     );
   }
 
-  Widget buildCurrentCard() {
+  Widget buildCardContent() {
     return Padding(
       padding: EdgeInsets.symmetric(
         vertical: ScreenSize.height * 0.02, 
@@ -47,7 +79,7 @@ class Cards extends StatelessWidget {
       child: Column(
         children: [
           buildCardHeader(),
-          buildCardBody(), 
+          buildCardSummary(), 
           Spacer(), 
           buildCardFooter()
         ]
@@ -84,7 +116,7 @@ class Cards extends StatelessWidget {
         Padding(
           padding: EdgeInsets.only(top: ScreenSize.height * 0.03), 
           child: FormatText(
-            text: dummyCard["name"],
+            text: dummyCard[matchIndex]["name"],
             fontSize: 22.0
           )
         )
@@ -92,9 +124,9 @@ class Cards extends StatelessWidget {
     );
   }
 
-  FormatText buildCardBody() {
+  FormatText buildCardSummary() {
     return FormatText(
-      text: dummyCard["description"], 
+      text: dummyCard[matchIndex]["description"], 
       fontSize: 12.0,
       fontWeight: FontWeight.w300,
       fontHeight: 1.6
@@ -106,7 +138,7 @@ class Cards extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         InkWell(
-          onTap: () => print("Arrow pressed"),
+          onTap: getNextCard,
           child: Image.asset(
             'images/right_arrow.png', 
             height: ScreenSize.height * 0.015

--- a/lib/pairings/cards.dart
+++ b/lib/pairings/cards.dart
@@ -6,7 +6,6 @@ import '../constants/constants.dart';
 
 class Cards extends StatefulWidget {
   const Cards({Key key}) : super(key: key);
-  
 
   @override
   State<StatefulWidget> createState() => _Cards();
@@ -62,11 +61,16 @@ class _Cards extends State<Cards> {
     );
   }
 
-  PrimaryButton buildReadMoreButton() {
-    return PrimaryButton(
-      isLight: true,
-      text: readMoreButtonText,
-      onPressed: () => print("Read more pressed")
+  BoxDecoration buildCardContainer() {
+    return BoxDecoration(
+      border: Border.all(
+        color: ThemeColors.accent,
+        width: 1.0,
+        style: BorderStyle.solid
+      ),
+      color: Colors.transparent,
+      shape: BoxShape.rectangle, 
+      borderRadius: BorderRadius.all(Radius.circular(20))
     );
   }
 
@@ -86,17 +90,12 @@ class _Cards extends State<Cards> {
       )
     );
   }
-
-  BoxDecoration buildCardContainer() {
-    return BoxDecoration(
-      border: Border.all(
-        color: ThemeColors.accent,
-        width: 1.0,
-        style: BorderStyle.solid
-      ),
-      color: Colors.transparent,
-      shape: BoxShape.rectangle, 
-      borderRadius: BorderRadius.all(Radius.circular(20))
+  
+  PrimaryButton buildReadMoreButton() {
+    return PrimaryButton(
+      isLight: true,
+      text: readMoreButtonText,
+      onPressed: () => print("Read more pressed")
     );
   }
 

--- a/lib/pairings/pairings.dart
+++ b/lib/pairings/pairings.dart
@@ -1,25 +1,68 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animator/flutter_animator.dart';
 
 import '../common/common.dart';
 import '../constants/constants.dart';
 
-class Pairings extends StatelessWidget {
+class Pairings extends StatefulWidget {
   const Pairings({Key key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => _Pairings();
+}
+
+class _Pairings extends State<Pairings> {
+  int matchIndex;
+  final GlobalKey<InOutAnimationState> inOutAnimationText = 
+  GlobalKey<InOutAnimationState>();
+  final GlobalKey<InOutAnimationState> upDownAno = 
+  GlobalKey<InOutAnimationState>();
+
+  @override
+  void initState() {
+    super.initState();
+
+    matchIndex = 0;
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: GlobalHeader(),
       backgroundColor: Colors.white,
-      body: Column(
+      body: Stack(
+        alignment: Alignment.center,
         children: [
-          buildAno(),
-          buildCards(context)
+          Positioned(
+            top: ScreenSize.height * 0.04, 
+            child: buildCardAnimation(context)
+          ),
+          Positioned(
+            bottom: 0, 
+            child: buildAnoAnimation()
+          )
         ]
       )
     );
   }
 
+  InOutAnimation buildAnoAnimation() {
+      return InOutAnimation(
+        key: upDownAno,
+        inDefinition: SlideInUpAnimation(),
+        outDefinition: SlideOutDownAnimation(),
+        child: buildAno()
+      );
+    }
+
+  InOutAnimation buildCardAnimation(context) {
+    return InOutAnimation(
+      key: inOutAnimationText,
+      inDefinition: SlideInRightAnimation(),
+      outDefinition: SlideOutLeftAnimation(),
+      child: buildCards(context)
+    );
+  }
 
   Image buildAno() {
     return Image.asset(
@@ -121,23 +164,20 @@ class Pairings extends StatelessWidget {
   }
 
   Widget buildCards(context) {
-    return Align(
-      alignment: Alignment.center, 
-      child: Container(
-        width: ScreenSize.width * 0.80,
-        height: ScreenSize.height * 0.42,
-        decoration: buildCardContainer(context), 
-        child: Stack(
-          overflow: Overflow.visible, 
-          alignment: Alignment.center, 
-          children: [
-            buildCurrentCard(context), 
-            Positioned(
-              top: ScreenSize.height * 0.39, 
-              child: buildReadMoreButton()
-            )
-          ]
-        )
+    return Container(
+      width: ScreenSize.width * 0.80,
+      height: ScreenSize.height * 0.42,
+      decoration: buildCardContainer(context), 
+      child: Stack(
+        overflow: Overflow.visible, 
+        alignment: Alignment.center, 
+        children: [
+          buildCurrentCard(context), 
+          Positioned(
+            top: ScreenSize.height * 0.39, 
+            child: buildReadMoreButton()
+          )
+        ]
       )
     );
   }

--- a/lib/pairings/pairings.dart
+++ b/lib/pairings/pairings.dart
@@ -4,26 +4,12 @@ import 'package:flutter_animator/flutter_animator.dart';
 import '../common/common.dart';
 import './cards.dart';
 
-class Pairings extends StatefulWidget {
-  const Pairings({Key key}) : super(key: key);
-
-  @override
-  State<StatefulWidget> createState() => _Pairings();
-}
-
-class _Pairings extends State<Pairings> {
-  int matchIndex;
-  final GlobalKey<InOutAnimationState> inOutAnimationCard = 
-    GlobalKey<InOutAnimationState>();
+class Pairings extends StatelessWidget {
   final GlobalKey<InOutAnimationState> upDownAnimationAno = 
     GlobalKey<InOutAnimationState>();
-
-  @override
-  void initState() {
-    super.initState();
-
-    matchIndex = 0;
-  }
+  
+  Pairings({Key key}) : super(key: key);
+  
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +26,7 @@ class _Pairings extends State<Pairings> {
       children: [
         Positioned(
           top: ScreenSize.height * 0.04, 
-          child: buildCardAnimation()
+          child: Cards()
         ),
         Positioned(
           bottom: 0, 
@@ -63,15 +49,6 @@ class _Pairings extends State<Pairings> {
     return Image.asset(
       'images/ano_mountains.png',
       height: ScreenSize.height * 0.25
-    );
-  }
-
-  InOutAnimation buildCardAnimation() {
-    return InOutAnimation(
-      key: inOutAnimationCard,
-      inDefinition: SlideInRightAnimation(),
-      outDefinition: SlideOutLeftAnimation(),
-      child: Cards()
     );
   }
 

--- a/lib/pairings/pairings.dart
+++ b/lib/pairings/pairings.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_animator/flutter_animator.dart';
 
 import '../common/common.dart';
-import '../constants/constants.dart';
+import './cards.dart';
 
 class Pairings extends StatefulWidget {
   const Pairings({Key key}) : super(key: key);
@@ -13,10 +13,10 @@ class Pairings extends StatefulWidget {
 
 class _Pairings extends State<Pairings> {
   int matchIndex;
-  final GlobalKey<InOutAnimationState> inOutAnimationText = 
-  GlobalKey<InOutAnimationState>();
-  final GlobalKey<InOutAnimationState> upDownAno = 
-  GlobalKey<InOutAnimationState>();
+  final GlobalKey<InOutAnimationState> inOutAnimationCard = 
+    GlobalKey<InOutAnimationState>();
+  final GlobalKey<InOutAnimationState> upDownAnimationAno = 
+    GlobalKey<InOutAnimationState>();
 
   @override
   void initState() {
@@ -30,39 +30,34 @@ class _Pairings extends State<Pairings> {
     return Scaffold(
       appBar: GlobalHeader(),
       backgroundColor: Colors.white,
-      body: Stack(
-        alignment: Alignment.center,
-        children: [
-          Positioned(
-            top: ScreenSize.height * 0.04, 
-            child: buildCardAnimation(context)
-          ),
-          Positioned(
-            bottom: 0, 
-            child: buildAnoAnimation()
-          )
-        ]
-      )
+      body: buildPairings()
+    );
+  }
+
+  Stack buildPairings() {
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        Positioned(
+          top: ScreenSize.height * 0.04, 
+          child: buildCardAnimation()
+        ),
+        Positioned(
+          bottom: 0, 
+          child: buildAnoAnimation()
+        )
+      ]
     );
   }
 
   InOutAnimation buildAnoAnimation() {
       return InOutAnimation(
-        key: upDownAno,
+        key: upDownAnimationAno,
         inDefinition: SlideInUpAnimation(),
         outDefinition: SlideOutDownAnimation(),
         child: buildAno()
       );
     }
-
-  InOutAnimation buildCardAnimation(context) {
-    return InOutAnimation(
-      key: inOutAnimationText,
-      inDefinition: SlideInRightAnimation(),
-      outDefinition: SlideOutLeftAnimation(),
-      child: buildCards(context)
-    );
-  }
 
   Image buildAno() {
     return Image.asset(
@@ -71,114 +66,12 @@ class _Pairings extends State<Pairings> {
     );
   }
 
-  PrimaryButton buildReadMoreButton() {
-    return PrimaryButton(
-      isLight: true,
-      text: readMoreButtonText,
-      onPressed: () => print("Read more pressed")
-    );
-  }
-
-  Row buildCardHeader() {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Container(
-          width: ScreenSize.width * 0.10, 
-          height: ScreenSize.height * 0.10,
-          decoration: BoxDecoration(
-            color: Colors.grey[200], 
-            shape: BoxShape.circle
-          )
-        ), 
-        Padding(
-          padding: EdgeInsets.only(top: ScreenSize.height * 0.03), 
-          child: FormatText(
-            text: dummyCard["name"],
-            fontSize: 22.0
-          )
-        )
-      ]
-    );
-  }
-
-  FormatText buildCardBody() {
-    return FormatText(
-      text: dummyCard["description"], 
-      fontSize: 12.0,
-      fontWeight: FontWeight.w300,
-      fontHeight: 1.6
-    );
-  }
-  
-  Row buildCardFooter(context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        InkWell(
-          onTap: () => print("Arrow pressed"),
-          child: Image.asset(
-            'images/right_arrow.png', 
-            height: ScreenSize.height * 0.015
-          )
-        ),
-        IconButton(
-          icon: Icon(Icons.favorite),
-          iconSize: ScreenSize.height * 0.03, 
-          color: ThemeColors.accent,
-          onPressed: () => print("Heart pressed"),
-        )
-      ]
-    );
-  }
-
-  Widget buildCurrentCard(context) {
-    return Padding(
-      padding: EdgeInsets.symmetric(
-        vertical: ScreenSize.height * 0.02, 
-        horizontal: ScreenSize.width * 0.05
-      ),
-      child: Column(
-        children: [
-          buildCardHeader(),
-          buildCardBody(), 
-          Spacer(), 
-          buildCardFooter(context)
-        ]
-      )
-    );
-  }
-
-  BoxDecoration buildCardContainer(context) {
-    return BoxDecoration(
-      border: Border.all(
-        color: ThemeColors.accent,
-        width: 1.0,
-        style: BorderStyle.solid
-      ),
-      color: Colors.transparent,
-      shape: BoxShape.rectangle, 
-      borderRadius: BorderRadius.all(Radius.circular(20))
-    );
-  }
-
-  Widget buildCards(context) {
-    return Container(
-      width: ScreenSize.width * 0.80,
-      height: ScreenSize.height * 0.42,
-      decoration: buildCardContainer(context), 
-      child: Stack(
-        overflow: Overflow.visible, 
-        alignment: Alignment.center, 
-        children: [
-          buildCurrentCard(context), 
-          Positioned(
-            top: ScreenSize.height * 0.39, 
-            child: buildReadMoreButton()
-          )
-        ]
-      )
+  InOutAnimation buildCardAnimation() {
+    return InOutAnimation(
+      key: inOutAnimationCard,
+      inDefinition: SlideInRightAnimation(),
+      outDefinition: SlideOutLeftAnimation(),
+      child: Cards()
     );
   }
 


### PR DESCRIPTION
**Changes**
- move ano to bottom and make it slide up
- add slide left and right animations to cards
- move cards outside of pairings into its own `Cards` widget

**UI**
> iPhone 11
> <img src="https://user-images.githubusercontent.com/23146829/89727086-f5eae300-d9de-11ea-8f9f-6bd2fdf4d9c7.gif" width="300px" />

> iPhone SE
> <img src="https://user-images.githubusercontent.com/23146829/89727250-08195100-d9e0-11ea-8423-972358aeb00a.png" width="300px" />



